### PR TITLE
Separate HTML templates

### DIFF
--- a/templates/index_template.html
+++ b/templates/index_template.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Is there poo in the river?</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; text-align: center; }
+        table { border-collapse: collapse; margin: 2em auto 0 auto; }
+        th, td { border: 1px solid #aaa; padding: 0.7em 1.5em; text-align: center; font-size: 1.2em; }
+        th { background: #e3f1fa; }
+        tr:nth-child(even) { background: #f9f9f9; }
+        .risk-high { color: red; font-weight: bold; font-size: 1.5em; }
+        .risk-medium { color: orange; font-weight: bold; font-size: 1.2em; }
+        .risk-low { color: green; font-weight: bold; font-size: 1.2em; }
+        .poo-emoji { font-size: 2em; vertical-align: middle; }
+        caption { font-size: 1.3em; font-weight: bold; margin-bottom: 1em; }
+    </style>
+    <script src="https://cdn.counter.dev/script.js" data-id="99522e23-c138-4047-babb-1e1503dd4a6f" data-utcoffset="1"></script>
+</head>
+<body>
+    <h1>Is there poo in the river?</h1>
+
+    <div class="generated-time">Report generated: $report_time. If if has rained since then, the data may be inaccurate</div>
+</br>
+<div class="generated-time">The risk is based entirely on the author's personal risk tolerance. River swimming is never 100% safe, so it's up to you to make an informed decision </div>
+</br>
+<div class="generated-time">This system is currently being tested and may produce unexpected or inaccurate results, but it's trying it's hardest</div>
+
+
+    <table>
+        <caption>Swim sites and current risk</caption>
+        <tr>
+            <th>Site</th>
+            <th>Risk Level</th>
+            <th>Details</th>
+        </tr>
+        $table_rows
+    </table>
+    <div style="margin-top:1.5em;font-size:0.95em;color:#444;">
+        Reports are based on storm overflow data and automated "upstream" calculations for each site. See detailed reports for logic and disclaimers.
+    </div>
+</body>
+</html>

--- a/templates/report_template.html
+++ b/templates/report_template.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Is there poo in $river_label?</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 2em;
+            text-align: center;
+        }
+        h1 { color: #006699; text-align: center; }
+        table {
+            border-collapse: collapse;
+            margin: 1.5em auto 0 auto;
+            text-align: center;
+        }
+        th, td {
+            border: 1px solid #aaa;
+            padding: 0.5em 1em;
+            text-align: center;
+        }
+        th { background: #e3f1fa; }
+        tr:nth-child(even) { background: #f9f9f9; }
+        caption {
+            font-weight: bold;
+            font-size: 1.1em;
+            margin-bottom: 0.5em;
+            text-align: center;
+        }
+        .risk-high { color: red; font-weight: bold; font-size: 2.2em; }
+        .risk-medium { color: orange; font-weight: bold; font-size: 2.2em; }
+        .risk-low { color: green; font-weight: bold; font-size: 2.2em; }
+        .poo-emoji {
+            font-size: 4em;
+            display: block;
+            text-align: center;
+            margin: 0.3em 0;
+        }
+        .disclaimer {
+            font-size: 0.95em;
+            color: #444;
+            margin-top: 1em;
+            text-align: center;
+        }
+        .risk-level-line {
+            margin-top: 0.5em;
+            margin-bottom: 0.5em;
+            font-size: 2.2em;
+            font-weight: bold;
+        }
+        .generated-time {
+            font-size: 1.1em;
+            color: #333;
+            margin-bottom: 1em;
+            margin-top: 0;
+            text-align: center;
+        }
+    </style>
+    <script src="https://cdn.counter.dev/script.js" data-id="99522e23-c138-4047-babb-1e1503dd4a6f" data-utcoffset="1"></script>
+</head>
+<body>
+<h1>Is there poo in $river_label?</h1>
+$poo_emoji_block
+<div class="risk-level-line">
+    Risk level = <span class="risk-$risk_lower">$risk</span>
+</div>
+
+<div class="generated-time">Report generated: $report_time. If if has rained since then, the data may be inaccurate</div>
+</br>
+<div class="generated-time">The risk is based entirely on the author's personal risk tolerance. River swimming is never 100% safe, so it's up to you to make an informed decision </div>
+</br>
+<div class="generated-time">This system is currently being tested and may produce unexpected or inaccurate results, but it's trying it's hardest</div>
+
+
+
+<table>
+    <caption>Total storm overflows in the last two days upstream of $river_label by distance</caption>
+    <tr>
+        <th>Distance Band</th>
+        <th>Total Duration</th>
+    </tr>
+    $table_rows
+</table>
+<div class="disclaimer">
+    This tool uses a simplified "upstream" test based on longitude and/or latitude. For Conham, CSOs east of the site are counted as upstream. This may include or miss some actual upstream sources, especially in complex river sections.
+    <br>Distances are as the crow flies (not measured along the river or watercourse).
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extract report and index HTML into `templates/`
- refactor `poo.py` to load HTML from template files

## Testing
- `python poo.py` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6878da9877ac832d8c6a777ae925f799