### PR TITLE
Add weather warnings based on openmeteo forecast

### DIFF
--- a/templates/index_template.html
+++ b/templates/index_template.html
@@ -14,6 +14,7 @@
         .risk-low { color: green; font-weight: bold; font-size: 1.2em; }
         .poo-emoji { font-size: 2em; vertical-align: middle; }
         caption { font-size: 1.3em; font-weight: bold; margin-bottom: 1em; }
+        .rain-warning { font-size: 1.1em; color: #2255aa; font-weight: bold; margin-top: 1em; }
     </style>
     <script src="https://cdn.counter.dev/script.js" data-id="99522e23-c138-4047-babb-1e1503dd4a6f" data-utcoffset="1"></script>
 </head>
@@ -36,6 +37,7 @@
         </tr>
         $table_rows
     </table>
+    <div class="rain-warning">$weather_message_index</div>
     <div style="margin-top:1.5em;font-size:0.95em;color:#444;">
         Reports are based on storm overflow data and automated "upstream" calculations for each site. See detailed reports for logic and disclaimers.
     </div>

--- a/templates/report_template.html
+++ b/templates/report_template.html
@@ -56,6 +56,13 @@
             margin-top: 0;
             text-align: center;
         }
+        .rain-warning {
+            font-size: 1.1em;
+            color: #2255aa;
+            font-weight: bold;
+            margin-top: 1em;
+            text-align: center;
+        }
     </style>
     <script src="https://cdn.counter.dev/script.js" data-id="99522e23-c138-4047-babb-1e1503dd4a6f" data-utcoffset="1"></script>
 </head>
@@ -82,6 +89,7 @@ $poo_emoji_block
     </tr>
     $table_rows
 </table>
+<div class="rain-warning">$weather_message</div>
 <div class="disclaimer">
     This tool uses a simplified "upstream" test based on longitude and/or latitude. For Conham, CSOs east of the site are counted as upstream. This may include or miss some actual upstream sources, especially in complex river sections.
     <br>Distances are as the crow flies (not measured along the river or watercourse).


### PR DESCRIPTION
## Summary
- pull precipitation forecasts from open-meteo
- show rain warnings for each site if more than 5mm is forecast in the next three days
- display any site warnings on the index page

## Testing
- `python poo.py` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6878de89c394832dbc21b7fcddd4f1b9