### PR TITLE
Add theme options with external stylesheet

### DIFF
--- a/docs/chew.html
+++ b/docs/chew.html
@@ -4,63 +4,10 @@
 <head>
     <meta charset="utf-8">
     <title>Is there poo in River Chew at Publow?</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            margin: 2em;
-            text-align: center;
-        }
-        h1 { color: #006699; text-align: center; }
-        table {
-            border-collapse: collapse;
-            margin: 1.5em auto 0 auto;
-            text-align: center;
-        }
-        th, td {
-            border: 1px solid #aaa;
-            padding: 0.5em 1em;
-            text-align: center;
-        }
-        th { background: #e3f1fa; }
-        tr:nth-child(even) { background: #f9f9f9; }
-        caption {
-            font-weight: bold;
-            font-size: 1.1em;
-            margin-bottom: 0.5em;
-            text-align: center;
-        }
-        .risk-high { color: red; font-weight: bold; font-size: 2.2em; }
-        .risk-medium { color: orange; font-weight: bold; font-size: 2.2em; }
-        .risk-low { color: green; font-weight: bold; font-size: 2.2em; }
-        .poo-emoji {
-            font-size: 4em;
-            display: block;
-            text-align: center;
-            margin: 0.3em 0;
-        }
-        .disclaimer {
-            font-size: 0.95em;
-            color: #444;
-            margin-top: 1em;
-            text-align: center;
-        }
-        .risk-level-line {
-            margin-top: 0.5em;
-            margin-bottom: 0.5em;
-            font-size: 2.2em;
-            font-weight: bold;
-        }
-        .generated-time {
-            font-size: 1.1em;
-            color: #333;
-            margin-bottom: 1em;
-            margin-top: 0;
-            text-align: center;
-        }
-    </style>
+    <link rel="stylesheet" href="styles.css">
     <script src="https://cdn.counter.dev/script.js" data-id="99522e23-c138-4047-babb-1e1503dd4a6f" data-utcoffset="1"></script>
 </head>
-<body>
+<body class="theme-light">
 <h1>Is there poo in River Chew at Publow?</h1>
 
 <div class="risk-level-line">

--- a/docs/conham.html
+++ b/docs/conham.html
@@ -4,63 +4,10 @@
 <head>
     <meta charset="utf-8">
     <title>Is there poo in Avon at Conham River?</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            margin: 2em;
-            text-align: center;
-        }
-        h1 { color: #006699; text-align: center; }
-        table {
-            border-collapse: collapse;
-            margin: 1.5em auto 0 auto;
-            text-align: center;
-        }
-        th, td {
-            border: 1px solid #aaa;
-            padding: 0.5em 1em;
-            text-align: center;
-        }
-        th { background: #e3f1fa; }
-        tr:nth-child(even) { background: #f9f9f9; }
-        caption {
-            font-weight: bold;
-            font-size: 1.1em;
-            margin-bottom: 0.5em;
-            text-align: center;
-        }
-        .risk-high { color: red; font-weight: bold; font-size: 2.2em; }
-        .risk-medium { color: orange; font-weight: bold; font-size: 2.2em; }
-        .risk-low { color: green; font-weight: bold; font-size: 2.2em; }
-        .poo-emoji {
-            font-size: 4em;
-            display: block;
-            text-align: center;
-            margin: 0.3em 0;
-        }
-        .disclaimer {
-            font-size: 0.95em;
-            color: #444;
-            margin-top: 1em;
-            text-align: center;
-        }
-        .risk-level-line {
-            margin-top: 0.5em;
-            margin-bottom: 0.5em;
-            font-size: 2.2em;
-            font-weight: bold;
-        }
-        .generated-time {
-            font-size: 1.1em;
-            color: #333;
-            margin-bottom: 1em;
-            margin-top: 0;
-            text-align: center;
-        }
-    </style>
+    <link rel="stylesheet" href="styles.css">
     <script src="https://cdn.counter.dev/script.js" data-id="99522e23-c138-4047-babb-1e1503dd4a6f" data-utcoffset="1"></script>
 </head>
-<body>
+<body class="theme-light">
 <h1>Is there poo in Avon at Conham River?</h1>
 
 <div class="risk-level-line">

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,21 +4,10 @@
 <head>
     <meta charset="utf-8">
     <title>Is there poo in the river?</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin: 2em; text-align: center; }
-        table { border-collapse: collapse; margin: 2em auto 0 auto; }
-        th, td { border: 1px solid #aaa; padding: 0.7em 1.5em; text-align: center; font-size: 1.2em; }
-        th { background: #e3f1fa; }
-        tr:nth-child(even) { background: #f9f9f9; }
-        .risk-high { color: red; font-weight: bold; font-size: 1.5em; }
-        .risk-medium { color: orange; font-weight: bold; font-size: 1.2em; }
-        .risk-low { color: green; font-weight: bold; font-size: 1.2em; }
-        .poo-emoji { font-size: 2em; vertical-align: middle; }
-        caption { font-size: 1.3em; font-weight: bold; margin-bottom: 1em; }
-    </style>
+    <link rel="stylesheet" href="styles.css">
     <script src="https://cdn.counter.dev/script.js" data-id="99522e23-c138-4047-babb-1e1503dd4a6f" data-utcoffset="1"></script>
 </head>
-<body>
+<body class="theme-light">
     <h1>Is there poo in the river?</h1>
     
     <div class="generated-time">Report generated: 2025-07-17 09:37:24. If if has rained since then, the data may be inaccurate</div>

--- a/docs/salford.html
+++ b/docs/salford.html
@@ -4,63 +4,10 @@
 <head>
     <meta charset="utf-8">
     <title>Is there poo in Avon at Salford?</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            margin: 2em;
-            text-align: center;
-        }
-        h1 { color: #006699; text-align: center; }
-        table {
-            border-collapse: collapse;
-            margin: 1.5em auto 0 auto;
-            text-align: center;
-        }
-        th, td {
-            border: 1px solid #aaa;
-            padding: 0.5em 1em;
-            text-align: center;
-        }
-        th { background: #e3f1fa; }
-        tr:nth-child(even) { background: #f9f9f9; }
-        caption {
-            font-weight: bold;
-            font-size: 1.1em;
-            margin-bottom: 0.5em;
-            text-align: center;
-        }
-        .risk-high { color: red; font-weight: bold; font-size: 2.2em; }
-        .risk-medium { color: orange; font-weight: bold; font-size: 2.2em; }
-        .risk-low { color: green; font-weight: bold; font-size: 2.2em; }
-        .poo-emoji {
-            font-size: 4em;
-            display: block;
-            text-align: center;
-            margin: 0.3em 0;
-        }
-        .disclaimer {
-            font-size: 0.95em;
-            color: #444;
-            margin-top: 1em;
-            text-align: center;
-        }
-        .risk-level-line {
-            margin-top: 0.5em;
-            margin-bottom: 0.5em;
-            font-size: 2.2em;
-            font-weight: bold;
-        }
-        .generated-time {
-            font-size: 1.1em;
-            color: #333;
-            margin-bottom: 1em;
-            margin-top: 0;
-            text-align: center;
-        }
-    </style>
+    <link rel="stylesheet" href="styles.css">
     <script src="https://cdn.counter.dev/script.js" data-id="99522e23-c138-4047-babb-1e1503dd4a6f" data-utcoffset="1"></script>
 </head>
-<body>
+<body class="theme-light">
 <h1>Is there poo in Avon at Salford?</h1>
 
 <div class="risk-level-line">

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,137 @@
+/* Base styling shared across themes */
+body {
+    font-family: Arial, sans-serif;
+    margin: 2em;
+    text-align: center;
+    background-color: var(--bg);
+    color: var(--text);
+}
+
+h1 {
+    color: var(--heading);
+    text-align: center;
+}
+
+table {
+    border-collapse: collapse;
+    margin: 1.5em auto 0 auto;
+    text-align: center;
+}
+
+th, td {
+    border: 1px solid var(--border);
+    padding: 0.7em 1.5em;
+    text-align: center;
+}
+
+th {
+    background: var(--header-bg);
+}
+
+tr:nth-child(even) {
+    background: var(--row-even);
+}
+
+caption {
+    font-size: 1.3em;
+    font-weight: bold;
+    margin-bottom: 1em;
+}
+
+.risk-high {
+    color: var(--risk-high);
+    font-weight: bold;
+    font-size: 1.5em;
+}
+
+.risk-medium {
+    color: var(--risk-medium);
+    font-weight: bold;
+    font-size: 1.2em;
+}
+
+.risk-low {
+    color: var(--risk-low);
+    font-weight: bold;
+    font-size: 1.2em;
+}
+
+.poo-emoji {
+    font-size: 2em;
+    vertical-align: middle;
+}
+
+.disclaimer {
+    font-size: 0.95em;
+    color: var(--text-secondary);
+    margin-top: 1em;
+    text-align: center;
+}
+
+.risk-level-line {
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+    font-size: 2.2em;
+    font-weight: bold;
+}
+
+.generated-time {
+    font-size: 1.1em;
+    color: var(--text);
+    margin-bottom: 1em;
+    margin-top: 0;
+    text-align: center;
+}
+
+.rain-warning {
+    font-size: 1.1em;
+    color: var(--rain);
+    font-weight: bold;
+    margin-top: 1em;
+    text-align: center;
+}
+
+/* Light theme (default) */
+.theme-light {
+    --bg: #ffffff;
+    --text: #000000;
+    --text-secondary: #444444;
+    --header-bg: #e3f1fa;
+    --row-even: #f9f9f9;
+    --border: #aaaaaa;
+    --heading: #006699;
+    --risk-high: red;
+    --risk-medium: orange;
+    --risk-low: green;
+    --rain: #2255aa;
+}
+
+/* Dark theme */
+.theme-dark {
+    --bg: #111111;
+    --text: #eeeeee;
+    --text-secondary: #cccccc;
+    --header-bg: #333333;
+    --row-even: #222222;
+    --border: #555555;
+    --heading: #66bbee;
+    --risk-high: #ff7777;
+    --risk-medium: #ffbb44;
+    --risk-low: #88ee88;
+    --rain: #7aa9ff;
+}
+
+/* Ocean theme */
+.theme-ocean {
+    --bg: #f0fbff;
+    --text: #023859;
+    --text-secondary: #02556e;
+    --header-bg: #d0ecff;
+    --row-even: #e8f6ff;
+    --border: #8ab4f8;
+    --heading: #0277b2;
+    --risk-high: #d62c2c;
+    --risk-medium: #ff851b;
+    --risk-low: #1f8a70;
+    --rain: #025e8f;
+}

--- a/docs/warleigh.html
+++ b/docs/warleigh.html
@@ -4,63 +4,10 @@
 <head>
     <meta charset="utf-8">
     <title>Is there poo in Avon at Warleigh Weir?</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            margin: 2em;
-            text-align: center;
-        }
-        h1 { color: #006699; text-align: center; }
-        table {
-            border-collapse: collapse;
-            margin: 1.5em auto 0 auto;
-            text-align: center;
-        }
-        th, td {
-            border: 1px solid #aaa;
-            padding: 0.5em 1em;
-            text-align: center;
-        }
-        th { background: #e3f1fa; }
-        tr:nth-child(even) { background: #f9f9f9; }
-        caption {
-            font-weight: bold;
-            font-size: 1.1em;
-            margin-bottom: 0.5em;
-            text-align: center;
-        }
-        .risk-high { color: red; font-weight: bold; font-size: 2.2em; }
-        .risk-medium { color: orange; font-weight: bold; font-size: 2.2em; }
-        .risk-low { color: green; font-weight: bold; font-size: 2.2em; }
-        .poo-emoji {
-            font-size: 4em;
-            display: block;
-            text-align: center;
-            margin: 0.3em 0;
-        }
-        .disclaimer {
-            font-size: 0.95em;
-            color: #444;
-            margin-top: 1em;
-            text-align: center;
-        }
-        .risk-level-line {
-            margin-top: 0.5em;
-            margin-bottom: 0.5em;
-            font-size: 2.2em;
-            font-weight: bold;
-        }
-        .generated-time {
-            font-size: 1.1em;
-            color: #333;
-            margin-bottom: 1em;
-            margin-top: 0;
-            text-align: center;
-        }
-    </style>
+    <link rel="stylesheet" href="styles.css">
     <script src="https://cdn.counter.dev/script.js" data-id="99522e23-c138-4047-babb-1e1503dd4a6f" data-utcoffset="1"></script>
 </head>
-<body>
+<body class="theme-light">
 <h1>Is there poo in Avon at Warleigh Weir?</h1>
 
 <div class="risk-level-line">

--- a/templates/index_template.html
+++ b/templates/index_template.html
@@ -3,22 +3,10 @@
 <head>
     <meta charset="utf-8">
     <title>Is there poo in the river?</title>
-    <style>
-        body { font-family: Arial, sans-serif; margin: 2em; text-align: center; }
-        table { border-collapse: collapse; margin: 2em auto 0 auto; }
-        th, td { border: 1px solid #aaa; padding: 0.7em 1.5em; text-align: center; font-size: 1.2em; }
-        th { background: #e3f1fa; }
-        tr:nth-child(even) { background: #f9f9f9; }
-        .risk-high { color: red; font-weight: bold; font-size: 1.5em; }
-        .risk-medium { color: orange; font-weight: bold; font-size: 1.2em; }
-        .risk-low { color: green; font-weight: bold; font-size: 1.2em; }
-        .poo-emoji { font-size: 2em; vertical-align: middle; }
-        caption { font-size: 1.3em; font-weight: bold; margin-bottom: 1em; }
-        .rain-warning { font-size: 1.1em; color: #2255aa; font-weight: bold; margin-top: 1em; }
-    </style>
+    <link rel="stylesheet" href="styles.css">
     <script src="https://cdn.counter.dev/script.js" data-id="99522e23-c138-4047-babb-1e1503dd4a6f" data-utcoffset="1"></script>
 </head>
-<body>
+<body class="theme-light">
     <h1>Is there poo in the river?</h1>
 
     <div class="generated-time">Report generated: $report_time. If if has rained since then, the data may be inaccurate</div>

--- a/templates/report_template.html
+++ b/templates/report_template.html
@@ -3,70 +3,10 @@
 <head>
     <meta charset="utf-8">
     <title>Is there poo in $river_label?</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            margin: 2em;
-            text-align: center;
-        }
-        h1 { color: #006699; text-align: center; }
-        table {
-            border-collapse: collapse;
-            margin: 1.5em auto 0 auto;
-            text-align: center;
-        }
-        th, td {
-            border: 1px solid #aaa;
-            padding: 0.5em 1em;
-            text-align: center;
-        }
-        th { background: #e3f1fa; }
-        tr:nth-child(even) { background: #f9f9f9; }
-        caption {
-            font-weight: bold;
-            font-size: 1.1em;
-            margin-bottom: 0.5em;
-            text-align: center;
-        }
-        .risk-high { color: red; font-weight: bold; font-size: 2.2em; }
-        .risk-medium { color: orange; font-weight: bold; font-size: 2.2em; }
-        .risk-low { color: green; font-weight: bold; font-size: 2.2em; }
-        .poo-emoji {
-            font-size: 4em;
-            display: block;
-            text-align: center;
-            margin: 0.3em 0;
-        }
-        .disclaimer {
-            font-size: 0.95em;
-            color: #444;
-            margin-top: 1em;
-            text-align: center;
-        }
-        .risk-level-line {
-            margin-top: 0.5em;
-            margin-bottom: 0.5em;
-            font-size: 2.2em;
-            font-weight: bold;
-        }
-        .generated-time {
-            font-size: 1.1em;
-            color: #333;
-            margin-bottom: 1em;
-            margin-top: 0;
-            text-align: center;
-        }
-        .rain-warning {
-            font-size: 1.1em;
-            color: #2255aa;
-            font-weight: bold;
-            margin-top: 1em;
-            text-align: center;
-        }
-    </style>
+    <link rel="stylesheet" href="styles.css">
     <script src="https://cdn.counter.dev/script.js" data-id="99522e23-c138-4047-babb-1e1503dd4a6f" data-utcoffset="1"></script>
 </head>
-<body>
+<body class="theme-light">
 <h1>Is there poo in $river_label?</h1>
 $poo_emoji_block
 <div class="risk-level-line">

--- a/templates/styles.css
+++ b/templates/styles.css
@@ -1,0 +1,137 @@
+/* Base styling shared across themes */
+body {
+    font-family: Arial, sans-serif;
+    margin: 2em;
+    text-align: center;
+    background-color: var(--bg);
+    color: var(--text);
+}
+
+h1 {
+    color: var(--heading);
+    text-align: center;
+}
+
+table {
+    border-collapse: collapse;
+    margin: 1.5em auto 0 auto;
+    text-align: center;
+}
+
+th, td {
+    border: 1px solid var(--border);
+    padding: 0.7em 1.5em;
+    text-align: center;
+}
+
+th {
+    background: var(--header-bg);
+}
+
+tr:nth-child(even) {
+    background: var(--row-even);
+}
+
+caption {
+    font-size: 1.3em;
+    font-weight: bold;
+    margin-bottom: 1em;
+}
+
+.risk-high {
+    color: var(--risk-high);
+    font-weight: bold;
+    font-size: 1.5em;
+}
+
+.risk-medium {
+    color: var(--risk-medium);
+    font-weight: bold;
+    font-size: 1.2em;
+}
+
+.risk-low {
+    color: var(--risk-low);
+    font-weight: bold;
+    font-size: 1.2em;
+}
+
+.poo-emoji {
+    font-size: 2em;
+    vertical-align: middle;
+}
+
+.disclaimer {
+    font-size: 0.95em;
+    color: var(--text-secondary);
+    margin-top: 1em;
+    text-align: center;
+}
+
+.risk-level-line {
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+    font-size: 2.2em;
+    font-weight: bold;
+}
+
+.generated-time {
+    font-size: 1.1em;
+    color: var(--text);
+    margin-bottom: 1em;
+    margin-top: 0;
+    text-align: center;
+}
+
+.rain-warning {
+    font-size: 1.1em;
+    color: var(--rain);
+    font-weight: bold;
+    margin-top: 1em;
+    text-align: center;
+}
+
+/* Light theme (default) */
+.theme-light {
+    --bg: #ffffff;
+    --text: #000000;
+    --text-secondary: #444444;
+    --header-bg: #e3f1fa;
+    --row-even: #f9f9f9;
+    --border: #aaaaaa;
+    --heading: #006699;
+    --risk-high: red;
+    --risk-medium: orange;
+    --risk-low: green;
+    --rain: #2255aa;
+}
+
+/* Dark theme */
+.theme-dark {
+    --bg: #111111;
+    --text: #eeeeee;
+    --text-secondary: #cccccc;
+    --header-bg: #333333;
+    --row-even: #222222;
+    --border: #555555;
+    --heading: #66bbee;
+    --risk-high: #ff7777;
+    --risk-medium: #ffbb44;
+    --risk-low: #88ee88;
+    --rain: #7aa9ff;
+}
+
+/* Ocean theme */
+.theme-ocean {
+    --bg: #f0fbff;
+    --text: #023859;
+    --text-secondary: #02556e;
+    --header-bg: #d0ecff;
+    --row-even: #e8f6ff;
+    --border: #8ab4f8;
+    --heading: #0277b2;
+    --risk-high: #d62c2c;
+    --risk-medium: #ff851b;
+    --risk-low: #1f8a70;
+    --rain: #025e8f;
+}


### PR DESCRIPTION
## Summary
- introduce a single stylesheet with multiple themes
- update templates and generated pages to load the stylesheet
- default to the `theme-light` class on `<body>`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878e1144af8832da17cc198be949bf4