### PR TITLE
Add Leaflet map to index

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,8 @@
     <meta charset="utf-8">
     <title>Is there poo in the river?</title>
     <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-u2DjYv3X35mnG3OmOQpyaD4G1ygEfLTTs+kN2fP0h+c=" crossorigin="">
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-oM9Y9PykPH/3L7XQHzAXnxEvx6hE1Jzm1v9ZBysuG1w=" crossorigin=""></script>
     <script src="https://cdn.counter.dev/script.js" data-id="99522e23-c138-4047-babb-1e1503dd4a6f" data-utcoffset="1"></script>
 </head>
 <body class="theme-ocean">
@@ -46,8 +48,52 @@
     </tr>
     
     </table>
+    <div id="map" style="height: 400px; margin-top: 1em;"></div>
     <div style="margin-top:1.5em;font-size:0.95em;color:#444;">
         Reports are based on storm overflow data and automated "upstream" calculations for each site. See detailed reports for logic and disclaimers.
     </div>
+
+    <script>
+        const siteData = [{"site":"Avon at Conham River","filename":"conham.html","risk":"Medium","warnings":[],"lat":51.444858,"lon":-2.534812},{"site":"Avon at Salford","filename":"salford.html","risk":"Medium","warnings":[],"lat":51.444858,"lon":-2.534812},{"site":"Avon at Warleigh Weir","filename":"warleigh.html","risk":"Low","warnings":[],"lat":51.444858,"lon":-2.534812},{"site":"River Chew at Publow","filename":"chew.html","risk":"Medium","warnings":[],"lat":51.415847,"lon":-2.497921}];
+        const map = L.map('map').setView([51.44, -2.53], 10);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 19,
+            attribution: '© OpenStreetMap'
+        }).addTo(map);
+
+        const icons = {
+            High: L.icon({
+                iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png',
+                shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+                iconSize: [25, 41],
+                iconAnchor: [12, 41],
+                popupAnchor: [1, -34],
+                shadowSize: [41, 41]
+            }),
+            Medium: L.icon({
+                iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-orange.png',
+                shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+                iconSize: [25, 41],
+                iconAnchor: [12, 41],
+                popupAnchor: [1, -34],
+                shadowSize: [41, 41]
+            }),
+            Low: L.icon({
+                iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-green.png',
+                shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+                iconSize: [25, 41],
+                iconAnchor: [12, 41],
+                popupAnchor: [1, -34],
+                shadowSize: [41, 41]
+            })
+        };
+
+        siteData.forEach(site => {
+            const icon = icons[site.risk] || icons.Low;
+            L.marker([site.lat, site.lon], { icon })
+                .addTo(map)
+                .bindPopup(`<a href="${site.filename}">${site.site}</a>`);
+        });
+    </script>
 </body>
 </html>

--- a/poo.py
+++ b/poo.py
@@ -1,3 +1,4 @@
+import json
 import requests
 from datetime import datetime, timedelta
 from math import radians, sin, cos, sqrt, atan2
@@ -241,6 +242,8 @@ for r in reports:
         "filename": r["filename"] + ".html",
         "risk": risk,
         "warnings": warnings,
+        "lat": r["ref_lat"],
+        "lon": r["ref_lon"],
     })
     
 # Risk color classes, emoji if desired
@@ -280,6 +283,7 @@ index_html = tpl.substitute(
     report_time=report_time,
     table_rows=table_rows,
     weather_message_index=weather_message_index,
+    site_data=json.dumps(index_data),
 )
 
 with open("docs/index.html", "w", encoding="utf-8") as f:

--- a/templates/index_template.html
+++ b/templates/index_template.html
@@ -4,6 +4,15 @@
     <meta charset="utf-8">
     <title>Is there poo in the river?</title>
     <link rel="stylesheet" href="styles.css">
+    <link
+        rel="stylesheet"
+        href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+        integrity="sha256-u2DjYv3X35mnG3OmOQpyaD4G1ygEfLTTs+kN2fP0h+c="
+        crossorigin=""
+    />
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+        integrity="sha256-oM9Y9PykPH/3L7XQHzAXnxEvx6hE1Jzm1v9ZBysuG1w="
+        crossorigin=""></script>
     <script src="https://cdn.counter.dev/script.js" data-id="99522e23-c138-4047-babb-1e1503dd4a6f" data-utcoffset="1"></script>
 </head>
 <body class="theme-ocean">
@@ -25,9 +34,55 @@
         </tr>
         $table_rows
     </table>
+
+    <div id="map" style="height: 400px; margin-top: 1em;"></div>
+
     <div class="rain-warning">$weather_message_index</div>
     <div style="margin-top:1.5em;font-size:0.95em;color:#444;">
         Reports are based on storm overflow data and automated "upstream" calculations for each site. See detailed reports for logic and disclaimers.
     </div>
+
+    <script>
+        const siteData = $site_data;
+        const map = L.map('map').setView([51.44, -2.53], 10);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 19,
+            attribution: '© OpenStreetMap'
+        }).addTo(map);
+
+        const icons = {
+            High: L.icon({
+                iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-red.png',
+                shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+                iconSize: [25, 41],
+                iconAnchor: [12, 41],
+                popupAnchor: [1, -34],
+                shadowSize: [41, 41]
+            }),
+            Medium: L.icon({
+                iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-orange.png',
+                shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+                iconSize: [25, 41],
+                iconAnchor: [12, 41],
+                popupAnchor: [1, -34],
+                shadowSize: [41, 41]
+            }),
+            Low: L.icon({
+                iconUrl: 'https://raw.githubusercontent.com/pointhi/leaflet-color-markers/master/img/marker-icon-green.png',
+                shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
+                iconSize: [25, 41],
+                iconAnchor: [12, 41],
+                popupAnchor: [1, -34],
+                shadowSize: [41, 41]
+            })
+        };
+
+        siteData.forEach(site => {
+            const icon = icons[site.risk] || icons.Low;
+            L.marker([site.lat, site.lon], { icon })
+                .addTo(map)
+                .bindPopup(`<a href="${site.filename}">${site.site}</a>`);
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- embed Leaflet assets in the index template
- render a map of all sites with markers linking to their reports
- include risk-based coloured markers in the index
- update generated HTML with new map
- expose site coordinate data via `poo.py`

## Testing
- `python -m py_compile poo.py`

------
https://chatgpt.com/codex/tasks/task_e_6878e99ca78c832da428e69f9610e620