### PR TITLE
Add interactive map to index page

### DIFF
--- a/poo.py
+++ b/poo.py
@@ -2,6 +2,7 @@ import requests
 from datetime import datetime, timedelta
 from math import radians, sin, cos, sqrt, atan2
 import os
+import json
 from string import Template
 
 index_data = []
@@ -286,3 +287,32 @@ with open("docs/index.html", "w", encoding="utf-8") as f:
     f.write(index_html)
 
 print("Index page written to docs/index.html")
+
+# ----- Generate index.js for map markers -----
+spots = []
+for report, entry in zip(reports, index_data):
+    spots.append({
+        "lat": report["ref_lat"],
+        "lon": report["ref_lon"],
+        "risk": entry["risk"],
+        "link": entry["filename"],
+        "label": report["river_label"],
+    })
+
+center_lat = sum(r["ref_lat"] for r in reports) / len(reports)
+center_lon = sum(r["ref_lon"] for r in reports) / len(reports)
+
+js_template_path = os.path.join("templates", "index_js_template.js")
+with open(js_template_path, "r", encoding="utf-8") as tpl_file:
+    js_tpl = Template(tpl_file.read())
+
+index_js = js_tpl.substitute(
+    spots_json=json.dumps(spots),
+    center_lat=center_lat,
+    center_lon=center_lon,
+)
+
+with open("docs/index.js", "w", encoding="utf-8") as f:
+    f.write(index_js)
+
+print("Index JS written to docs/index.js")

--- a/templates/index_js_template.js
+++ b/templates/index_js_template.js
@@ -1,0 +1,23 @@
+const spots = $spots_json;
+
+var map = L.map('map').setView([$center_lat, $center_lon], 11);
+
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    maxZoom: 19,
+    attribution: '&copy; OpenStreetMap contributors'
+}).addTo(map);
+
+function createIcon(risk) {
+    return L.divIcon({
+        html: '<div class="marker-icon marker-' + risk.toLowerCase() + '"></div>',
+        iconSize: [20, 20],
+        iconAnchor: [10, 10],
+        className: ''
+    });
+}
+
+spots.forEach(function(s) {
+    var marker = L.marker([s.lat, s.lon], {icon: createIcon(s.risk)}).addTo(map);
+    marker.on('click', function() { window.location.href = s.link; });
+    marker.bindTooltip(s.label);
+});

--- a/templates/index_template.html
+++ b/templates/index_template.html
@@ -4,6 +4,9 @@
     <meta charset="utf-8">
     <title>Is there poo in the river?</title>
     <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+          integrity="sha256-sA+e2j5w8DNZv6nS3yoqO+NLMg9LrjronWYyvEqF5XQ="
+          crossorigin=""/>
     <script src="https://cdn.counter.dev/script.js" data-id="99522e23-c138-4047-babb-1e1503dd4a6f" data-utcoffset="1"></script>
 </head>
 <body class="theme-ocean">
@@ -25,9 +28,14 @@
         </tr>
         $table_rows
     </table>
+    <div id="map"></div>
     <div class="rain-warning">$weather_message_index</div>
     <div style="margin-top:1.5em;font-size:0.95em;color:#444;">
         Reports are based on storm overflow data and automated "upstream" calculations for each site. See detailed reports for logic and disclaimers.
     </div>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+            integrity="sha256-o9N1j7J3GxS0zHQ7tr0PeRDSA/A9F+gjkeZMnC1Og+w="
+            crossorigin=""></script>
+    <script src="index.js"></script>
 </body>
 </html>

--- a/templates/styles.css
+++ b/templates/styles.css
@@ -135,3 +135,21 @@ caption {
     --risk-low: #1f8a70;
     --rain: #025e8f;
 }
+
+/* Map styling */
+#map {
+    height: 400px;
+    margin: 2em auto;
+    width: 80%;
+}
+
+.marker-icon {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    border: 2px solid #fff;
+}
+
+.marker-high { background: var(--risk-high); }
+.marker-medium { background: var(--risk-medium); }
+.marker-low { background: var(--risk-low); }


### PR DESCRIPTION
## Summary
- add Leaflet styles and JS hooks in `index_template.html`
- create `index_js_template.js` to plot swim locations on map
- style map container and marker icons in CSS
- generate `index.js` from data in `poo.py`

## Testing
- `python3 poo.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6878ef0e931c832d95f53ad15ab0ce0b