### PR TITLE
Add map with dynamic risk markers

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <title>Is there poo in the river?</title>
     <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
     <script src="https://cdn.counter.dev/script.js" data-id="99522e23-c138-4047-babb-1e1503dd4a6f" data-utcoffset="1"></script>
 </head>
 <body class="theme-ocean">
@@ -44,10 +45,13 @@
         <td class="risk-medium">Medium </td>
         <td><a href="chew.html">View report</a></td>
     </tr>
-    
+
     </table>
+    <div id="map"></div>
     <div style="margin-top:1.5em;font-size:0.95em;color:#444;">
         Reports are based on storm overflow data and automated "upstream" calculations for each site. See detailed reports for logic and disclaimers.
     </div>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="index.js"></script>
 </body>
 </html>

--- a/docs/index.js
+++ b/docs/index.js
@@ -1,0 +1,24 @@
+const sites = [
+    {name: 'Avon at Conham River', lat: 51.444858, lon: -2.534812, risk: 'Medium', link: 'conham.html'},
+    {name: 'Avon at Salford', lat: 51.444858, lon: -2.534812, risk: 'Medium', link: 'salford.html'},
+    {name: 'Avon at Warleigh Weir', lat: 51.444858, lon: -2.534812, risk: 'Low', link: 'warleigh.html'},
+    {name: 'River Chew at Publow', lat: 51.415847, lon: -2.497921, risk: 'Medium', link: 'chew.html'}
+];
+const map = L.map('map').setView([51.445, -2.516], 10);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; OpenStreetMap contributors'
+}).addTo(map);
+
+sites.forEach(site => {
+    const color = site.risk === 'High' ? 'red' : site.risk === 'Medium' ? 'orange' : 'green';
+    const marker = L.circleMarker([site.lat, site.lon], {
+        radius: 8,
+        color: color,
+        fillColor: color,
+        fillOpacity: 0.8
+    }).addTo(map);
+    marker.bindTooltip(site.name);
+    marker.on('click', () => {
+        window.location.href = site.link;
+    });
+});

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -91,6 +91,11 @@ caption {
     text-align: center;
 }
 
+#map {
+    height: 400px;
+    margin-top: 1em;
+}
+
 /* Light theme (default) */
 .theme-light {
     --bg: #ffffff;

--- a/templates/index_js_template.js
+++ b/templates/index_js_template.js
@@ -1,0 +1,21 @@
+// Leaflet map initialization
+const sites = $sites_json;
+
+const map = L.map('map').setView([$center_lat, $center_lon], 10);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; OpenStreetMap contributors'
+}).addTo(map);
+
+sites.forEach(site => {
+    const color = site.risk === 'High' ? 'red' : site.risk === 'Medium' ? 'orange' : 'green';
+    const marker = L.circleMarker([site.lat, site.lon], {
+        radius: 8,
+        color: color,
+        fillColor: color,
+        fillOpacity: 0.8
+    }).addTo(map);
+    marker.bindTooltip(site.name);
+    marker.on('click', () => {
+        window.location.href = site.link;
+    });
+});

--- a/templates/index_template.html
+++ b/templates/index_template.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>Is there poo in the river?</title>
     <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
     <script src="https://cdn.counter.dev/script.js" data-id="99522e23-c138-4047-babb-1e1503dd4a6f" data-utcoffset="1"></script>
 </head>
 <body class="theme-ocean">
@@ -25,9 +26,12 @@
         </tr>
         $table_rows
     </table>
+    <div id="map"></div>
     <div class="rain-warning">$weather_message_index</div>
     <div style="margin-top:1.5em;font-size:0.95em;color:#444;">
         Reports are based on storm overflow data and automated "upstream" calculations for each site. See detailed reports for logic and disclaimers.
     </div>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="index.js"></script>
 </body>
 </html>

--- a/templates/styles.css
+++ b/templates/styles.css
@@ -91,6 +91,11 @@ caption {
     text-align: center;
 }
 
+#map {
+    height: 400px;
+    margin-top: 1em;
+}
+
 /* Light theme (default) */
 .theme-light {
     --bg: #ffffff;


### PR DESCRIPTION
## Summary
- add Leaflet map support to site templates
- generate index.js with map marker data
- style map container

## Testing
- `python3 -m py_compile poo.py`

------
https://chatgpt.com/codex/tasks/task_e_6878ef0e931c832d95f53ad15ab0ce0b