### PR TITLE
Align map and table side by side

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -17,21 +17,23 @@
 <div class="generated-time">This system is currently being tested and may produce unexpected or inaccurate results, but it's trying it's hardest</div>
 
 
-    <table>
-        <caption>Swim sites and current risk</caption>
-        <tr>
-            <th>Site</th>
-            <th>Risk Level</th>
-            <th>Details</th>
-        </tr>
-        <tr><td>Avon at Conham River</td><td class="risk-medium">Medium </td><td><a href="conham.html">View report</a></td></tr>
+    <div class="content-container">
+        <table>
+            <caption>Swim sites and current risk</caption>
+            <tr>
+                <th>Site</th>
+                <th>Risk Level</th>
+                <th>Details</th>
+            </tr>
+            <tr><td>Avon at Conham River</td><td class="risk-medium">Medium </td><td><a href="conham.html">View report</a></td></tr>
 <tr><td>Avon at Salford</td><td class="risk-medium">Medium </td><td><a href="salford.html">View report</a></td></tr>
 <tr><td>Avon at Warleigh Weir</td><td class="risk-low">Low </td><td><a href="warleigh.html">View report</a></td></tr>
 <tr><td>River Chew at Publow</td><td class="risk-medium">Medium </td><td><a href="chew.html">View report</a></td></tr>
 <tr><td>River Frome at Farleigh Hungerford</td><td class="risk-low">Low </td><td><a href="farleigh.html">View report</a></td></tr>
 
-    </table>
-    <div id="map"></div>
+        </table>
+        <div id="map"></div>
+    </div>
     <div class="rain-warning"></div>
     <div style="margin-top:1.5em;font-size:0.95em;color:#444;">
         Reports are based on storm overflow data and automated "upstream" calculations for each site. See detailed reports for logic and disclaimers.

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -7,6 +7,19 @@ body {
     color: var(--text);
 }
 
+.content-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: flex-start;
+    gap: 2em;
+}
+
+.content-container table,
+.content-container #map {
+    flex: 1 1 400px;
+}
+
 h1 {
     color: var(--heading);
     text-align: center;

--- a/templates/index_template.html
+++ b/templates/index_template.html
@@ -17,16 +17,18 @@
 <div class="generated-time">This system is currently being tested and may produce unexpected or inaccurate results, but it's trying it's hardest</div>
 
 
-    <table>
-        <caption>Swim sites and current risk</caption>
-        <tr>
-            <th>Site</th>
-            <th>Risk Level</th>
-            <th>Details</th>
-        </tr>
-        $table_rows
-    </table>
-    <div id="map"></div>
+    <div class="content-container">
+        <table>
+            <caption>Swim sites and current risk</caption>
+            <tr>
+                <th>Site</th>
+                <th>Risk Level</th>
+                <th>Details</th>
+            </tr>
+            $table_rows
+        </table>
+        <div id="map"></div>
+    </div>
     <div class="rain-warning">$weather_message_index</div>
     <div style="margin-top:1.5em;font-size:0.95em;color:#444;">
         Reports are based on storm overflow data and automated "upstream" calculations for each site. See detailed reports for logic and disclaimers.

--- a/templates/styles.css
+++ b/templates/styles.css
@@ -7,6 +7,19 @@ body {
     color: var(--text);
 }
 
+.content-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: flex-start;
+    gap: 2em;
+}
+
+.content-container table,
+.content-container #map {
+    flex: 1 1 400px;
+}
+
 h1 {
     color: var(--heading);
     text-align: center;


### PR DESCRIPTION
## Summary
- wrap map and table inside a new container in the index template
- apply flexbox styling to show map and table next to each other
- update generated docs with the new layout

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878f3639740832da51eb868abdcdbbf