### PR TITLE
Add risk note after last CSO

### DIFF
--- a/templates/report_template.html
+++ b/templates/report_template.html
@@ -12,6 +12,7 @@ $poo_emoji_block
 <div class="risk-level-line">
     Risk level = <span class="risk-$risk_lower">$risk</span>
 </div>
+$risk_note_block
 
 <div class="generated-time">Report generated: $report_time. If if has rained since then, the data may be inaccurate</div>
 </br>


### PR DESCRIPTION
## Summary
- track the end time of the most recent CSO in `generate_report`
- output an advisory note for medium/high risk cases 48 hours after the last CSO
- update the report template to display the note

## Testing
- `python poo.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687f59e4a328832d9bc015fb7b3c1bc2