### PR TITLE
Move heading above table and map

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -14,8 +14,8 @@
 
 
     <div class="content-container">
+        <h2 class="site-heading">Swim sites and current risk</h2>
         <table>
-            <caption>Swim sites and current risk</caption>
             <tr>
                 <th>Site</th>
                 <th>Risk Level</th>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -51,6 +51,14 @@ caption {
     margin-bottom: 1em;
 }
 
+.site-heading {
+    font-size: 1.3em;
+    font-weight: bold;
+    margin-bottom: 1em;
+    width: 100%;
+    text-align: center;
+}
+
 .risk-high {
     color: var(--risk-high);
     font-weight: bold;

--- a/templates/index_template.html
+++ b/templates/index_template.html
@@ -13,8 +13,8 @@
     <div class="generated-time">Report generated: $report_time. If if has rained since then, the data may be inaccurate</div>
 </br>
     <div class="content-container">
+        <h2 class="site-heading">Swim sites and current risk</h2>
         <table>
-            <caption>Swim sites and current risk</caption>
             <tr>
                 <th>Site</th>
                 <th>Risk Level</th>

--- a/templates/styles.css
+++ b/templates/styles.css
@@ -51,6 +51,14 @@ caption {
     margin-bottom: 1em;
 }
 
+.site-heading {
+    font-size: 1.3em;
+    font-weight: bold;
+    margin-bottom: 1em;
+    width: 100%;
+    text-align: center;
+}
+
 .risk-high {
     color: var(--risk-high);
     font-weight: bold;


### PR DESCRIPTION
## Summary
- put the "Swim sites and current risk" heading above the index table and map
- add `.site-heading` style for new heading placement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f65bb55e0832d9c3252226f684b02