### PR TITLE
Improve risk note visibility

### DIFF
--- a/templates/styles.css
+++ b/templates/styles.css
@@ -96,6 +96,12 @@ caption {
     font-weight: bold;
 }
 
+.risk-note {
+    font-size: 1.3em;
+    font-weight: bold;
+    margin-bottom: 0.5em;
+}
+
 .generated-time {
     font-size: 1.1em;
     color: var(--text);


### PR DESCRIPTION
## Summary
- increase prominence of risk note

## Testing
- `python poo.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_687f6ccee8d0832d967cf842ace7951f