### PR TITLE
Add home links to river pages

### DIFF
--- a/docs/chew.html
+++ b/docs/chew.html
@@ -9,6 +9,8 @@
 <body class="theme-ocean">
 <h1>Is there poo in River Chew at Publow?</h1>
 
+<div><a href="index.html">Back to home page</a></div>
+
 <div class="risk-level-line">
     Risk level = <span class="risk-low">Low</span>
 </div>

--- a/docs/conham.html
+++ b/docs/conham.html
@@ -9,6 +9,8 @@
 <body class="theme-ocean">
 <h1>Is there poo in Avon at Conham River?</h1>
 
+<div><a href="index.html">Back to home page</a></div>
+
 <div class="risk-level-line">
     Risk level = <span class="risk-low">Low</span>
 </div>

--- a/docs/farleigh.html
+++ b/docs/farleigh.html
@@ -9,6 +9,8 @@
 <body class="theme-ocean">
 <h1>Is there poo in River Frome at Farleigh Hungerford?</h1>
 
+<div><a href="index.html">Back to home page</a></div>
+
 <div class="risk-level-line">
     Risk level = <span class="risk-low">Low</span>
 </div>

--- a/docs/salford.html
+++ b/docs/salford.html
@@ -9,6 +9,8 @@
 <body class="theme-ocean">
 <h1>Is there poo in Avon at Salford?</h1>
 
+<div><a href="index.html">Back to home page</a></div>
+
 <div class="risk-level-line">
     Risk level = <span class="risk-low">Low</span>
 </div>

--- a/docs/warleigh.html
+++ b/docs/warleigh.html
@@ -9,6 +9,8 @@
 <body class="theme-ocean">
 <h1>Is there poo in Avon at Warleigh Weir?</h1>
 
+<div><a href="index.html">Back to home page</a></div>
+
 <div class="risk-level-line">
     Risk level = <span class="risk-low">Low</span>
 </div>

--- a/templates/report_template.html
+++ b/templates/report_template.html
@@ -8,6 +8,7 @@
 </head>
 <body class="theme-ocean">
 <h1>Is there poo in $river_label?</h1>
+<div><a href="index.html">Back to home page</a></div>
 $poo_emoji_block
 <div class="risk-level-line">
     Risk level = <span class="risk-$risk_lower">$risk</span>


### PR DESCRIPTION
## Summary
- allow navigation back to home by linking to index from every river report
- include the same link in the report template so future pages get it automatically

## Testing
- `python -m py_compile poo.py`


------
https://chatgpt.com/codex/tasks/task_e_6892296bc300832d958b0da312d6143d