### PR TITLE
Include 'river avon (via sws)' in query lists

### DIFF
--- a/poo.py
+++ b/poo.py
@@ -183,7 +183,7 @@ reports = [
         "river_name": "conham",
         "river_label": "Avon at Conham River",
         "rivers_to_query": [
-            'RIVER AVON', 'RIVER CHEW', 'charlton bottom via sws', 'bathford brook (s)', 'horsecombe brook', 'river avon via sws'
+            'RIVER AVON', 'RIVER CHEW', 'charlton bottom via sws', 'bathford brook (s)', 'horsecombe brook', 'river avon via sws', 'river avon (via sws)'
         ],
         "ref_lat": 51.444858,
         "ref_lon": -2.534812,
@@ -194,9 +194,9 @@ reports = [
         "river_name": "salford",
         "river_label": "Avon at Salford",
         "rivers_to_query": [
-            'RIVER AVON', 'bathford brook (s)', 'horsecombe brook', 'river avon via sws'
+            'RIVER AVON', 'bathford brook (s)', 'horsecombe brook', 'river avon via sws', 'river avon (via sws)'
         ],
-        "ref_lat": 51.398639, 
+        "ref_lat": 51.398639,
         "ref_lon": -2.446917,
         "filename": "salford",
         "upstream_func": is_upstream_salford,
@@ -205,7 +205,7 @@ reports = [
         "river_name": "warleigh",
         "river_label": "Avon at Warleigh Weir",
         "rivers_to_query": [
-            'RIVER AVON', 'bathford brook (s)','Bristol Avon', 'River Frome', 'river avon via sws'
+            'RIVER AVON', 'bathford brook (s)','Bristol Avon', 'River Frome', 'river avon via sws', 'river avon (via sws)'
         ],
         "ref_lat": 51.376556,
         "ref_lon":  -2.301611,


### PR DESCRIPTION
## Summary
- expand Conham, Salford, and Warleigh reports to also query `river avon (via sws)`

## Testing
- `python -m py_compile poo.py`


------
https://chatgpt.com/codex/tasks/task_e_68922a6ea6d0832d96498f4bc5641077