### PR TITLE
Fix sorting of degenerate features in correlation analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/scripts/analyze_conham_cso_ecoli.py
+++ b/scripts/analyze_conham_cso_ecoli.py
@@ -201,7 +201,10 @@ def model_table(rows: list[dict[str, object]]) -> list[dict[str, float | int | s
             r_value = pearson(x, y)
             rho = pearson(ranks(x), ranks(y))
             results.append({"lookback_days": lag, "feature": candidate, "n": len(lag_rows), "pearson_r": r_value, "r_squared": r_value * r_value if not math.isnan(r_value) else float("nan"), "spearman_rho": rho})
-    return sorted(results, key=lambda r: (-1 if math.isnan(float(r["r_squared"])) else -float(r["r_squared"]), r["lookback_days"], str(r["feature"])))
+    # Sort by descending R². R² lies in [0, 1], so -R² lies in [-1, 0]; use a
+    # positive sentinel for undefined (NaN) correlations so degenerate features
+    # with no variation sort to the bottom instead of tying with a perfect fit.
+    return sorted(results, key=lambda r: (1.0 if math.isnan(float(r["r_squared"])) else -float(r["r_squared"]), r["lookback_days"], str(r["feature"])))
 
 
 def write_report(path: Path, rows: list[dict[str, object]], models: list[dict[str, object]]) -> None:


### PR DESCRIPTION
## Summary
Fixed the sorting behavior for features with undefined correlations (NaN values) in the model analysis table. Previously, degenerate features with no variation were incorrectly sorted alongside perfect correlations; they now sort to the bottom as intended.

## Changes
- **Correlation sorting logic**: Changed the NaN sentinel value from `-1` to `1.0` in the sort key. Since R² values range from 0 to 1 (and are negated for descending sort, giving -1 to 0), using `1.0` ensures NaN correlations sort after all valid correlations instead of tying with perfect fits.
- **Code documentation**: Added clarifying comments explaining the sort key behavior and the rationale for the sentinel value choice.
- **Gitignore**: Added standard Python cache files to `.gitignore` (`__pycache__/` and `*.pyc`).

## Implementation Details
The sort key now uses `1.0` as the sentinel for NaN values, which is greater than any negated R² value in the range [-1, 0]. This ensures degenerate features (those with no variation, producing NaN correlations) consistently sort to the bottom of results, improving the usability of the analysis output.

https://claude.ai/code/session_011UsdQPMKUZoMoKQGpC6NTQ