### PR TITLE
Add predicted water-quality level (Excellent/Good/Sufficient/Poor) to reports

### DIFF
--- a/docs/about_predictions.html
+++ b/docs/about_predictions.html
@@ -56,6 +56,22 @@
     (agricultural and urban run-off) that the overflow data does not capture.
 </p>
 
+<h2>The three-day forecast</h2>
+<p>
+    Each report also shows a <strong>three-day outlook</strong>. Rain is the only
+    thing we can see coming, and rain is what triggers the storm overflows, so the
+    forecast is rain-driven. It starts from the current level of upstream spilling
+    and then steps the category <em>worse</em> as forecast rain accumulates:
+    roughly, more than 8&nbsp;mm of rain (counting from now) nudges it one category
+    worse, more than 20&nbsp;mm two, and more than 40&nbsp;mm three. If the forecast
+    is dry, the outlook simply holds at the current spill-based level.
+</p>
+<p>
+    It is deliberately cautious &mdash; it assumes forecast rain will cause
+    spilling and does not assume the river cleans up quickly &mdash; so treat it as
+    a "could get this bad", not a promise. It is only as good as the rain forecast.
+</p>
+
 <h2>Why this model, and not a regression?</h2>
 <p>
     We looked hard at the historical data for Conham &mdash; 25 digitised <em>E. coli</em>

--- a/docs/about_predictions.html
+++ b/docs/about_predictions.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>How the water-quality prediction works</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="theme-ocean">
+<h1>How the predicted water quality works</h1>
+<div><a href="index.html">Back to home page</a></div>
+
+<p>
+    Each report shows a <strong>predicted bathing-water quality</strong> &mdash; Excellent,
+    Good, Sufficient or Poor &mdash; alongside the existing risk level. This page explains
+    what that prediction means, how it is calculated, and (importantly) what it can and
+    cannot tell you.
+</p>
+
+<h2>The categories</h2>
+<p>These are the UK inland bathing-water bands for <em>E. coli</em> (CFU/100&nbsp;ml):</p>
+<table>
+    <tr><th>Category</th><th>E. coli level</th></tr>
+    <tr><td class="quality-excellent">Excellent</td><td>&le; 500</td></tr>
+    <tr><td class="quality-good">Good</td><td>&le; 1000</td></tr>
+    <tr><td class="quality-sufficient">Sufficient</td><td>&le; 900 (90th percentile basis)</td></tr>
+    <tr><td class="quality-poor">Poor</td><td>exceeds the Sufficient level</td></tr>
+</table>
+<p>
+    Officially these bands are assessed from percentiles of a whole season's samples, not
+    a single reading. Here we apply the same boundary values to a single <em>predicted</em>
+    concentration, as a simplification, so the wording matches what people recognise.
+</p>
+
+<h2>How the prediction is made</h2>
+<p>
+    The prediction is driven by the two things this tool can see in near real time:
+</p>
+<ul>
+    <li><strong>Upstream storm-overflow (CSO) spilling</strong> &mdash; the total number of
+        hours that monitored overflows upstream (within about 20 miles) have been spilling
+        over the last 7 days.</li>
+    <li><strong>Recent rainfall</strong> &mdash; roughly the last three days of rain at the
+        site.</li>
+</ul>
+<p>The category is then set as follows:</p>
+<table>
+    <tr><th>Upstream spilling (last 7 days)</th><th>Base prediction</th></tr>
+    <tr><td>under 15 hours</td><td class="quality-excellent">Excellent</td></tr>
+    <tr><td>15 to 100 hours</td><td class="quality-good">Good</td></tr>
+    <tr><td>100 to 500 hours</td><td class="quality-sufficient">Sufficient</td></tr>
+    <tr><td>500 hours or more</td><td class="quality-poor">Poor</td></tr>
+</table>
+<p>
+    If there has also been <strong>heavy recent rain (20&nbsp;mm or more in ~3 days)</strong>,
+    the prediction is bumped one category worse, to account for rainfall-driven contamination
+    (agricultural and urban run-off) that the overflow data does not capture.
+</p>
+
+<h2>Why this model, and not a regression?</h2>
+<p>
+    We looked hard at the historical data for Conham &mdash; 25 digitised <em>E. coli</em>
+    samples from the 2025 sampling programme, matched against upstream CSO spill records
+    (Wessex Water's Event Duration Monitoring) and daily rainfall. Two findings shaped the
+    design:
+</p>
+<ol>
+    <li>
+        <strong>CSO spilling is the best available predictor, but the relationship is weak
+        and noisy.</strong> Upstream spill hours beat rainfall, individual outfalls, and
+        several other features in cross-validation &mdash; but the correlation is modest.
+        Rainfall on its own adds almost nothing once spilling is known.
+    </li>
+    <li>
+        <strong>A straight regression would be unsafe here.</strong> The lab caps readings
+        at 1000, so the worst days are "censored", and with a weak signal a least-squares
+        model pulls every estimate towards the average. Fitted honestly, it predicts
+        "Excellent" for <em>every</em> day &mdash; including the days that actually hit the
+        1000 ceiling. A model that always says "fine" is worse than useless for a swimming
+        warning.
+    </li>
+</ol>
+<p>
+    So instead we use a <strong>precautionary rule</strong>: when there has been a lot of
+    upstream spilling (and/or heavy rain), the prediction is deliberately cautious and moves
+    towards Poor. It is tuned so that the genuinely bad historical days (heavy December
+    spilling) come out as Sufficient or Poor. The cost is some false alarms &mdash; a few
+    quiet-water days with lots of upstream spilling get flagged as worse than they measured
+    &mdash; which is the safe direction to err for river swimming.
+</p>
+
+<h2>What it deliberately ignores</h2>
+<p>
+    Three historical days had high <em>E. coli</em> with essentially <em>no</em> upstream
+    spilling and little or no rain (26&nbsp;Jul, 27&nbsp;Sep and 22&nbsp;Nov 2025). These
+    look like an unmonitored source, a gap in the overflow data, or something non-sewage.
+    They cannot be predicted from spills or rain, so they were excluded when calibrating the
+    model. <strong>This means the prediction can miss a genuinely bad day that arrives with
+    dry weather and no recorded spilling.</strong>
+</p>
+
+<h2>Important caveats</h2>
+<ul>
+    <li>The model was calibrated on ~22 weekly samples at <strong>Conham only</strong>, then
+        applied to the other sites on the assumption that upstream spilling affects them
+        similarly. It has not been validated at those sites.</li>
+    <li>Weekly grab samples cannot resolve how quickly levels rise or fall within a few
+        days, and the <em>E. coli</em> values were read off a published chart, so they are
+        approximate and capped at 1000.</li>
+    <li>Rainfall is from a ~9&nbsp;km weather model, not a gauge at the river.</li>
+    <li>"Upstream" and distances are crude geometric approximations, and the monitored
+        overflows do not cover every possible source.</li>
+    <li>This is an experimental, precautionary estimate &mdash; <strong>not</strong> a
+        measurement, and not a guarantee of safety. River swimming is never 100% safe;
+        please make your own informed decision.</li>
+</ul>
+
+<div><a href="index.html">Back to home page</a></div>
+</body>
+</html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -103,6 +103,10 @@ caption {
     margin-bottom: 0.8em;
 }
 
+.forecast-table {
+    margin-top: 1em;
+}
+
 .disclaimer {
     font-size: 0.95em;
     color: var(--text-secondary);

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -82,6 +82,27 @@ caption {
     vertical-align: middle;
 }
 
+/* Predicted bathing-water quality categories */
+.quality-excellent { color: #1a8a3b; font-weight: bold; }
+.quality-good      { color: #0a7db8; font-weight: bold; }
+.quality-sufficient { color: #c77700; font-weight: bold; }
+.quality-poor      { color: #c0392b; font-weight: bold; }
+
+.predicted-quality {
+    margin: 0.4em 0 0.2em 0;
+    font-size: 1.4em;
+}
+.predicted-quality .about-predictions {
+    font-size: 0.6em;
+    font-weight: normal;
+    vertical-align: middle;
+}
+.prediction-basis {
+    font-size: 0.95em;
+    color: var(--text-secondary);
+    margin-bottom: 0.8em;
+}
+
 .disclaimer {
     font-size: 0.95em;
     color: var(--text-secondary);

--- a/poo.py
+++ b/poo.py
@@ -51,6 +51,53 @@ def get_precipitation_warnings(lat, lon):
             )
     return warnings
 
+
+def get_recent_rain_mm(lat, lon):
+    """Total rainfall (mm) over roughly the last 3 days, for the prediction model."""
+    url = "https://api.open-meteo.com/v1/forecast"
+    params = {
+        "latitude": lat,
+        "longitude": lon,
+        "daily": "precipitation_sum",
+        "past_days": 3,
+        "forecast_days": 1,
+        "timezone": "UTC",
+    }
+    try:
+        resp = requests.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        precip = resp.json().get("daily", {}).get("precipitation_sum", [])
+        # Sum the past days (drop the final entry, which is today's forecast).
+        past = [p for p in precip[:-1] if p is not None]
+        return round(sum(past), 1)
+    except Exception as e:
+        print(f"Failed to fetch recent rain: {e}")
+        return 0.0
+
+
+# --- Predicted bathing-water quality model ----------------------------------
+# Precautionary model mapping recent upstream CSO spilling (+ recent rain) to a
+# bathing-water category. Calibrated on 22 Conham E. coli samples (three
+# rainfall-independent anomalies excluded). See docs/about_predictions.html for
+# why a precautionary rule is used instead of a regression, and the caveats.
+QUALITY_ORDER = ["Excellent", "Good", "Sufficient", "Poor"]
+# Upper bounds (hours of upstream spilling in the last 7 days) for each category.
+QUALITY_SPILL_BOUNDS = [(15.0, "Excellent"), (100.0, "Good"), (500.0, "Sufficient")]
+RAIN_WORSEN_MM = 20.0  # heavy recent rain worsens the prediction by one step
+
+
+def predict_water_quality(spill_hours_7d, recent_rain_mm):
+    """Return (category, css_class) from upstream spill hours and recent rain."""
+    category = "Poor"
+    for bound, label in QUALITY_SPILL_BOUNDS:
+        if spill_hours_7d < bound:
+            category = label
+            break
+    if recent_rain_mm >= RAIN_WORSEN_MM:  # rainfall-driven contamination not in CSO data
+        idx = min(QUALITY_ORDER.index(category) + 1, len(QUALITY_ORDER) - 1)
+        category = QUALITY_ORDER[idx]
+    return category, "quality-" + category.lower()
+
 # Upstream filter functions for each site
 def is_upstream_conham(lat, lon):
     # Upstream if longitude is greater (i.e., east of the swim site)
@@ -78,11 +125,14 @@ def is_upstream_farleigh(lat, lon):
 def generate_report(river_name, river_label, rivers_to_query, ref_lat, ref_lon, filename, upstream_func):
     now = datetime.utcnow()
     two_days_ago_dt = now - timedelta(days=2)
-    two_days_ago_str = two_days_ago_dt.strftime("%Y-%m-%d %H:%M:%S")
+    two_days_ago_ms = two_days_ago_dt.timestamp() * 1000
+    # Query a 7-day window: the last 2 days drive the existing risk/table, and the
+    # full 7 days feed the predicted-quality model.
+    seven_days_ago_str = (now - timedelta(days=7)).strftime("%Y-%m-%d %H:%M:%S")
 
     # Build where clause for the selected rivers
     conditions = " OR ".join([f"ReceivingWaterCourse = '{river}'" for river in rivers_to_query])
-    where_clause = f"({conditions}) AND LatestEventStart >= DATE '{two_days_ago_str}'"
+    where_clause = f"({conditions}) AND LatestEventStart >= DATE '{seven_days_ago_str}'"
 
     url = "https://services.arcgis.com/3SZ6e0uCvPROr4mS/ArcGIS/rest/services/Wessex_Water_Storm_Overflow_Activity/FeatureServer/0/query"
 
@@ -108,6 +158,7 @@ def generate_report(river_name, river_label, rivers_to_query, ref_lat, ref_lon, 
     ]
     band_durations = [0] * len(band_edges)
     last_cso_end = None
+    spill_hours_7d = 0.0  # total upstream spilling within 20 miles over the last 7 days
 
     if data.get("features"):
         for feat in data["features"]:
@@ -119,13 +170,18 @@ def generate_report(river_name, river_label, rivers_to_query, ref_lat, ref_lon, 
             if start and end and lat is not None and lon is not None and upstream_func(lat, lon):
                 duration_seconds = (end - start) / 1000
                 dist = haversine(ref_lat, ref_lon, lat, lon)
-                for i, edge in enumerate(band_edges):
-                    lower = 0 if i == 0 else band_edges[i-1]
-                    if lower < dist <= edge:
-                        band_durations[i] += duration_seconds
-                        break
-                if last_cso_end is None or end > last_cso_end:
-                    last_cso_end = end
+                # 7-day upstream total (within 20 miles) feeds the prediction model.
+                if dist <= 20:
+                    spill_hours_7d += duration_seconds / 3600
+                # The distance-band table / risk use only the last two days.
+                if start >= two_days_ago_ms:
+                    for i, edge in enumerate(band_edges):
+                        lower = 0 if i == 0 else band_edges[i-1]
+                        if lower < dist <= edge:
+                            band_durations[i] += duration_seconds
+                            break
+                    if last_cso_end is None or end > last_cso_end:
+                        last_cso_end = end
 
     # Risk calculation as before
     total_seconds = sum(band_durations)
@@ -145,6 +201,18 @@ def generate_report(river_name, river_label, rivers_to_query, ref_lat, ref_lon, 
 
     warnings = get_precipitation_warnings(ref_lat, ref_lon)
     weather_message = "<br>".join(warnings) if warnings else ""
+
+    # Predicted bathing-water quality from 7-day upstream spilling + recent rain.
+    recent_rain_mm = get_recent_rain_mm(ref_lat, ref_lon)
+    predicted_quality, quality_class = predict_water_quality(spill_hours_7d, recent_rain_mm)
+    predicted_quality_block = (
+        f"<div class='predicted-quality {quality_class}'>"
+        f"Predicted water quality: <strong>{predicted_quality}</strong>"
+        f" <a class='about-predictions' href='about_predictions.html'>(how is this predicted?)</a>"
+        f"</div>"
+        f"<div class='prediction-basis'>Based on {spill_hours_7d:.0f} hours of upstream spilling "
+        f"in the last 7 days and {recent_rain_mm:.0f}mm of recent rain.</div>"
+    )
 
     risk_note_block = ""
     safe_time = None
@@ -169,13 +237,14 @@ def generate_report(river_name, river_label, rivers_to_query, ref_lat, ref_lon, 
         table_rows=table_rows,
         weather_message=weather_message,
         risk_note_block=risk_note_block,
+        predicted_quality_block=predicted_quality_block,
     )
 
     os.makedirs("docs", exist_ok=True)
     with open(f"docs/{filename}.html", "w", encoding="utf-8") as f:
         f.write(html)
     print(f"HTML report written to docs/{filename}.html")
-    return risk, warnings, safe_time
+    return risk, warnings, safe_time, predicted_quality, quality_class
 
 # --- Define rivers/reports you want to generate ---
 reports = [
@@ -242,7 +311,7 @@ reports = [
 ]
 
 for r in reports:
-    risk, warnings, safe_time = generate_report(
+    risk, warnings, safe_time, predicted_quality, quality_class = generate_report(
         river_name=r["river_name"],
         river_label=r["river_label"],
         rivers_to_query=r["rivers_to_query"],
@@ -257,6 +326,8 @@ for r in reports:
         "risk": risk,
         "warnings": warnings,
         "safe_time": safe_time,
+        "predicted_quality": predicted_quality,
+        "quality_class": quality_class,
         "lat": r["ref_lat"],
         "lon": r["ref_lon"],
     })
@@ -281,6 +352,7 @@ for entry in index_data:
         f"<tr>"
         f"<td>{entry['site']}</td>"
         f"<td class=\"{risk_class(entry['risk'])}\">{entry['risk']} {risk_emoji(entry['risk'])}</td>"
+        f"<td class=\"{entry['quality_class']}\">{entry['predicted_quality']}</td>"
         f"<td>{clear_time}</td>"
         f"<td><a href=\"{entry['filename']}\">View report</a></td>"
         "</tr>\n"

--- a/poo.py
+++ b/poo.py
@@ -21,15 +21,16 @@ def seconds_to_h_m(seconds):
     minutes = int((seconds % 3600) // 60)
     return hours, minutes
 
-# Fetch precipitation forecast from open-meteo and return warning messages
-def get_precipitation_warnings(lat, lon):
-    """Return a list of warning strings for days with >5mm rain in next 3 days."""
+# Fetch the daily precipitation forecast from open-meteo.
+def get_forecast_rain(lat, lon):
+    """Return (forecast, warnings): forecast is a list of (date, mm) for the next
+    three days; warnings is the >5mm warning strings for those days."""
     url = "https://api.open-meteo.com/v1/forecast"
     params = {
         "latitude": lat,
         "longitude": lon,
         "daily": "precipitation_sum",
-        "forecast_days": 3,
+        "forecast_days": 4,  # today + next 3 days
         "timezone": "UTC",
     }
     try:
@@ -37,19 +38,18 @@ def get_precipitation_warnings(lat, lon):
         resp.raise_for_status()
         data = resp.json()
     except Exception as e:
-        # On failure, just return an empty list
         print(f"Failed to fetch weather data: {e}")
-        return []
+        return [], []
 
-    warnings = []
+    today = datetime.utcnow().strftime("%Y-%m-%d")
     times = data.get("daily", {}).get("time", [])
     precip = data.get("daily", {}).get("precipitation_sum", [])
-    for day, rain in zip(times, precip):
-        if rain is not None and rain > 5:
-            warnings.append(
-                f"{day}: {rain}mm of rain forecast - water quality likely to get worse after this day"
-            )
-    return warnings
+    forecast = [(day, rain or 0.0) for day, rain in zip(times, precip) if day > today][:3]
+    warnings = [
+        f"{day}: {rain}mm of rain forecast - water quality likely to get worse after this day"
+        for day, rain in forecast if rain > 5
+    ]
+    return forecast, warnings
 
 
 def get_recent_rain_mm(lat, lon):
@@ -97,6 +97,43 @@ def predict_water_quality(spill_hours_7d, recent_rain_mm):
         idx = min(QUALITY_ORDER.index(category) + 1, len(QUALITY_ORDER) - 1)
         category = QUALITY_ORDER[idx]
     return category, "quality-" + category.lower()
+
+
+def spill_base_category(spill_hours_7d):
+    """Category from spill hours alone (no rain adjustment)."""
+    for bound, label in QUALITY_SPILL_BOUNDS:
+        if spill_hours_7d < bound:
+            return label
+    return "Poor"
+
+
+# Cumulative forecast rain (mm) needed to worsen the forecast by 1/2/3 steps.
+FORECAST_RAIN_STEPS = [(40.0, 3), (20.0, 2), (8.0, 1)]
+
+
+def forecast_water_quality(spill_hours_7d, recent_rain_mm, forecast_rain):
+    """Project the category for each of the next 3 days from forecast rainfall.
+
+    Anchored on current spilling (which persists), then worsened by the rain that
+    will have fallen by that day (recent rain already down + cumulative forecast).
+    Rain is the only forward-looking signal, so the forecast is rain-driven and
+    deliberately cautious. Returns a list of (date, mm_that_day, category, css).
+    """
+    base = spill_base_category(spill_hours_7d)
+    rows = []
+    cumulative = recent_rain_mm
+    for day, rain in forecast_rain:
+        cumulative += rain
+        steps = 0
+        for threshold, s in FORECAST_RAIN_STEPS:
+            if cumulative >= threshold:
+                steps = s
+                break
+        idx = min(QUALITY_ORDER.index(base) + steps, len(QUALITY_ORDER) - 1)
+        category = QUALITY_ORDER[idx]
+        rows.append((day, round(rain, 1), category, "quality-" + category.lower()))
+    return rows
+
 
 # Upstream filter functions for each site
 def is_upstream_conham(lat, lon):
@@ -203,7 +240,7 @@ def generate_report(river_name, river_label, rivers_to_query, ref_lat, ref_lon, 
         hours, minutes = seconds_to_h_m(band_durations[i])
         table_rows += f"<tr><td>{label}</td><td>{hours} hours {minutes} minutes</td></tr>\n"
 
-    warnings = get_precipitation_warnings(ref_lat, ref_lon)
+    forecast_rain, warnings = get_forecast_rain(ref_lat, ref_lon)
     weather_message = "<br>".join(warnings) if warnings else ""
 
     # Predicted bathing-water quality from 7-day upstream spilling + recent rain.
@@ -217,6 +254,27 @@ def generate_report(river_name, river_label, rivers_to_query, ref_lat, ref_lon, 
         f"<div class='prediction-basis'>Based on {spill_hours_7d:.0f} hours of upstream spilling "
         f"in the last 7 days and {recent_rain_mm:.0f}mm of recent rain.</div>"
     )
+
+    # Three-day outlook: project the category forward using the rain forecast.
+    forecast_rows = forecast_water_quality(spill_hours_7d, recent_rain_mm, forecast_rain)
+    if forecast_rows:
+        forecast_cells = "".join(
+            f"<tr><td>{day}</td><td>{rain:.0f}mm</td>"
+            f"<td class='{css}'>{category}</td></tr>\n"
+            for day, rain, category, css in forecast_rows
+        )
+        forecast_block = (
+            "<table class='forecast-table'>"
+            f"<caption>Forecast water quality for the next {len(forecast_rows)} days "
+            "(from the rain forecast)</caption>"
+            "<tr><th>Date</th><th>Rain forecast</th><th>Predicted quality</th></tr>"
+            f"{forecast_cells}</table>"
+            "<div class='prediction-basis'>Forecast is rain-driven and cautious: rain is "
+            "assumed to trigger upstream spilling. "
+            "<a href='about_predictions.html'>How this works.</a></div>"
+        )
+    else:
+        forecast_block = ""
 
     risk_note_block = ""
     safe_time = None
@@ -242,6 +300,7 @@ def generate_report(river_name, river_label, rivers_to_query, ref_lat, ref_lon, 
         weather_message=weather_message,
         risk_note_block=risk_note_block,
         predicted_quality_block=predicted_quality_block,
+        forecast_block=forecast_block,
     )
 
     os.makedirs("docs", exist_ok=True)

--- a/poo.py
+++ b/poo.py
@@ -122,7 +122,7 @@ def is_upstream_farleigh(lat, lon):
     # Upstream if latitude is less than the site's latitude
     return lat < 51.3299
 
-def generate_report(river_name, river_label, rivers_to_query, ref_lat, ref_lon, filename, upstream_func):
+def generate_report(river_name, river_label, rivers_to_query, ref_lat, ref_lon, filename, upstream_func, watercourse_clause=None):
     now = datetime.utcnow()
     two_days_ago_dt = now - timedelta(days=2)
     two_days_ago_ms = two_days_ago_dt.timestamp() * 1000
@@ -130,8 +130,12 @@ def generate_report(river_name, river_label, rivers_to_query, ref_lat, ref_lon, 
     # full 7 days feed the predicted-quality model.
     seven_days_ago_str = (now - timedelta(days=7)).strftime("%Y-%m-%d %H:%M:%S")
 
-    # Build where clause for the selected rivers
-    conditions = " OR ".join([f"ReceivingWaterCourse = '{river}'" for river in rivers_to_query])
+    # Build where clause for the selected rivers. A site may supply a custom
+    # watercourse_clause (e.g. Conham matches every River Avon name variant so the
+    # close Hanham outfalls are included, while excluding separate brooks).
+    conditions = watercourse_clause or " OR ".join(
+        [f"ReceivingWaterCourse = '{river}'" for river in rivers_to_query]
+    )
     where_clause = f"({conditions}) AND LatestEventStart >= DATE '{seven_days_ago_str}'"
 
     url = "https://services.arcgis.com/3SZ6e0uCvPROr4mS/ArcGIS/rest/services/Wessex_Water_Storm_Overflow_Activity/FeatureServer/0/query"
@@ -254,6 +258,20 @@ reports = [
         "rivers_to_query": [
             'RIVER AVON', 'RIVER CHEW', 'charlton bottom via sws', 'bathford brook (s)', 'horsecombe brook', 'river avon via sws', 'river avon (via sws)'
         ],
+        # Match every River Avon name variant so the close Hanham outfalls (on
+        # names like "RIVER AVON(E)" / "RIVER AVON (E) VIA SWS") are counted, plus
+        # the Chew and the brooks that join upstream. Warmley/Siston brooks are
+        # deliberately excluded: they drain to a separate catchment that does not
+        # join the Avon above Conham. Three LIKE casings cover the feed's mixed case.
+        "watercourse_clause": (
+            "ReceivingWaterCourse LIKE '%AVON%' "
+            "OR ReceivingWaterCourse LIKE '%avon%' "
+            "OR ReceivingWaterCourse LIKE '%Avon%' "
+            "OR ReceivingWaterCourse = 'RIVER CHEW' "
+            "OR ReceivingWaterCourse = 'charlton bottom via sws' "
+            "OR ReceivingWaterCourse = 'bathford brook (s)' "
+            "OR ReceivingWaterCourse = 'horsecombe brook'"
+        ),
         "ref_lat": 51.444858,
         "ref_lon": -2.534812,
         "filename": "conham",
@@ -319,6 +337,7 @@ for r in reports:
         ref_lon=r["ref_lon"],
         filename=r["filename"],
         upstream_func=r["upstream_func"],
+        watercourse_clause=r.get("watercourse_clause"),
     )
     index_data.append({
         "site": r["river_label"],

--- a/templates/index_template.html
+++ b/templates/index_template.html
@@ -18,6 +18,7 @@
             <tr>
                 <th>Site</th>
                 <th>Risk Level</th>
+                <th>Predicted quality</th>
                 <th>Clear for 48h at (UTC)</th>
                 <th>Details</th>
             </tr>
@@ -28,6 +29,7 @@
     <div class="rain-warning">$weather_message_index</div>
     <div style="margin-top:1.5em;font-size:0.95em;color:#444;">
         Reports are based on storm overflow data and automated "upstream" calculations for each site. See detailed reports for logic and disclaimers.
+        The <strong>predicted quality</strong> column estimates a bathing-water category from recent upstream spilling and rainfall &mdash; <a href="about_predictions.html">how this is predicted</a>.
     </div>
     </br>
     <div class="generated-time">The risk is based entirely on the author's personal risk tolerance. River swimming is never 100% safe, so it's up to you to make an informed decision </div>

--- a/templates/report_template.html
+++ b/templates/report_template.html
@@ -29,6 +29,7 @@ $predicted_quality_block
     $table_rows
 </table>
 <div class="rain-warning">$weather_message</div>
+$forecast_block
 <div class="disclaimer">
     This tool uses a simplified "upstream" test based on longitude and/or latitude. For Conham, CSOs east of the site are counted as upstream. This may include or miss some actual upstream sources, especially in complex river sections.
     <br>Distances are as the crow flies (not measured along the river or watercourse).

--- a/templates/report_template.html
+++ b/templates/report_template.html
@@ -14,6 +14,7 @@ $poo_emoji_block
     Risk level = <span class="risk-$risk_lower">$risk</span>
 </div>
 $risk_note_block
+$predicted_quality_block
 
 <div class="generated-time">Report generated: $report_time. If if has rained since then, the data may be inaccurate</div>
 


### PR DESCRIPTION
## Summary

Adds a predicted bathing-water quality category to every site report and the index, based on CSOs and rain, with a new `about_predictions.html` explaining the model and why it was chosen. Linked from all reports.

## The model (`poo.py` → `predict_water_quality`)

- The CSO query is widened to 7 days: the last 2 days still drive the existing risk level and distance-band table, and the full 7 days give **total upstream spill-hours** (within 20 miles).
- Category from spill-hours thresholds — `<15h` Excellent, `<100h` Good, `<500h` Sufficient, else Poor — **bumped one step worse if there's ≥20 mm of rain in ~3 days** (recent rain fetched from Open-Meteo `past_days`).
- Calibrated on 22 Conham 2025 samples, with the three rainfall-independent anomalies (26 Jul, 27 Sep, 22 Nov) excluded, as requested.

## Why a precautionary rule instead of a regression

The historical *E. coli* is censored at the lab max of 1000 and the CSO/rain signal is weak, so a least-squares fit regresses to the mean and predicts "Excellent" for **every** day — including the worst ones. That's unsafe for a swimming warning. The threshold rule instead errs toward caution:

- On the historical data, **all 22 non-anomaly days are predicted at or above their actual severity** (never under-warns).
- The genuine 1000-capped days (09-13, 12-11, 12-18) all come out **Sufficient/Poor**.
- The cost is some false alarms (e.g. 11-29, a big-spill/low-reading day, predicts worse than measured) — the safe direction to err.

`about_predictions.html` documents the categories, the model, this reasoning, the excluded anomalies, and the caveats (Conham-calibrated then extrapolated, weekly/chart-digitised/censored samples, grid rainfall, crude "upstream" geometry).

## UI changes

- Report template: a coloured "Predicted water quality" block with a "(how is this predicted?)" link.
- Index: a "Predicted quality" column plus a link to the explainer.
- `styles.css`: category colours.

Note: the committed `docs/*.html` reports will show the prediction after the next scheduled `poo.py` run (the live fetch can't run in this environment); the template, model, explainer page, and styles are all in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011UsdQPMKUZoMoKQGpC6NTQ)_