### PR TITLE
Publish on push to main so merges deploy immediately

### DIFF
--- a/.github/workflows/publish-cso.yml
+++ b/.github/workflows/publish-cso.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '15 */3 * * *'      # every hour at :15, adjust as needed
   workflow_dispatch:
+  push:
+    branches: [main]           # republish immediately when main changes
+    paths-ignore:
+      - 'docs/**'              # skip the bot's own regenerated-report commits
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Fixes the "I merged but the site didn't change" problem. The publish workflow only triggered on a 3-hourly `schedule` and manual `workflow_dispatch` — there was **no `push` trigger** — so merging to `main` did not regenerate/redeploy the reports until the next scheduled run.

## Change

Add a `push` trigger on `main`:

```yaml
  push:
    branches: [main]
    paths-ignore:
      - 'docs/**'
```

`docs/**` is path-ignored so the workflow's own "Update report [skip ci]" commits (which only touch `docs/`) don't re-trigger it — belt-and-braces with the existing `[skip ci]`. Pushes that change `poo.py`, the templates, or the workflow will now republish immediately.

## Context

This is why the predicted-quality / forecast changes from #31 weren't showing: no run had executed on the merged commit. I manually dispatched a run to publish them now (it succeeded and the reports now show the prediction and 3-day forecast); this PR prevents the delay from happening again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011UsdQPMKUZoMoKQGpC6NTQ)_