### PR TITLE
Add 2025-style CSO, rainfall & temperature chart to swim-site reports

### DIFF
--- a/poo.py
+++ b/poo.py
@@ -1,11 +1,17 @@
 import requests
 from datetime import datetime, timedelta
 from math import radians, sin, cos, sqrt, atan2
+from collections import defaultdict
 import os
 import json
 from string import Template
 
 index_data = []
+
+# Number of days of history shown in the per-site "recent" chart (styled after
+# the 2025 review page). A 7-day pre-roll is fetched on top of this so the
+# trailing 2-/7-day cumulative CSO sums are complete from the first plotted day.
+CHART_DAYS = 45
 
 def haversine(lat1, lon1, lat2, lon2):
     R = 3958.8  # Earth radius in miles
@@ -52,6 +58,41 @@ def get_forecast_rain(lat, lon):
     return warnings
 
 
+# Fetch recent daily rainfall and mean temperature for the swim site, used by the
+# per-site history chart. Uses the open-meteo forecast endpoint with `past_days`
+# so it returns a continuous daily series ending today (no separate archive key).
+def get_daily_weather(lat, lon, past_days=CHART_DAYS):
+    """Return {YYYY-MM-DD: (rain_mm, temp_mean_c)} for the last ``past_days``
+    days up to and including today. Missing values are None."""
+    url = "https://api.open-meteo.com/v1/forecast"
+    params = {
+        "latitude": lat,
+        "longitude": lon,
+        "daily": "precipitation_sum,temperature_2m_mean",
+        "past_days": past_days,
+        "forecast_days": 1,  # include today
+        "timezone": "UTC",
+    }
+    try:
+        resp = requests.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as e:
+        print(f"Failed to fetch daily weather: {e}")
+        return {}
+
+    daily = data.get("daily", {})
+    times = daily.get("time", [])
+    precip = daily.get("precipitation_sum", [])
+    temp = daily.get("temperature_2m_mean", [])
+    out = {}
+    for i, day in enumerate(times):
+        r = precip[i] if i < len(precip) else None
+        t = temp[i] if i < len(temp) else None
+        out[day] = (r, t)
+    return out
+
+
 # Upstream filter functions for each site
 def is_upstream_conham(lat, lon):
     # Upstream if longitude is greater (i.e., east of the swim site)
@@ -80,9 +121,11 @@ def generate_report(river_name, river_label, rivers_to_query, ref_lat, ref_lon, 
     now = datetime.utcnow()
     two_days_ago_dt = now - timedelta(days=2)
     two_days_ago_ms = two_days_ago_dt.timestamp() * 1000
-    # Query a 7-day window so the feed comfortably covers the last two days that
-    # drive the risk level and the distance-band table.
-    seven_days_ago_str = (now - timedelta(days=7)).strftime("%Y-%m-%d %H:%M:%S")
+    # Query a window wide enough to cover both the last two days that drive the
+    # risk level / distance-band table AND the CHART_DAYS history chart, plus a
+    # 7-day pre-roll so the chart's trailing 7-day CSO sums are complete from its
+    # first plotted day.
+    fetch_from_str = (now - timedelta(days=CHART_DAYS + 7)).strftime("%Y-%m-%d %H:%M:%S")
 
     # Build where clause for the selected rivers. A site may supply a custom
     # watercourse_clause (e.g. Conham matches every River Avon name variant so the
@@ -90,7 +133,7 @@ def generate_report(river_name, river_label, rivers_to_query, ref_lat, ref_lon, 
     conditions = watercourse_clause or " OR ".join(
         [f"ReceivingWaterCourse = '{river}'" for river in rivers_to_query]
     )
-    where_clause = f"({conditions}) AND LatestEventStart >= DATE '{seven_days_ago_str}'"
+    where_clause = f"({conditions}) AND LatestEventStart >= DATE '{fetch_from_str}'"
 
     url = "https://services.arcgis.com/3SZ6e0uCvPROr4mS/ArcGIS/rest/services/Wessex_Water_Storm_Overflow_Activity/FeatureServer/0/query"
 
@@ -116,6 +159,10 @@ def generate_report(river_name, river_label, rivers_to_query, ref_lat, ref_lon, 
     ]
     band_durations = [0] * len(band_edges)
     last_cso_end = None
+    # Upstream spill hours attributed to each calendar day (by event start day),
+    # feeding the per-site history chart's same-day / trailing-2d / trailing-7d
+    # panels. Mirrors scripts/daily_cso.py's aggregation.
+    by_day_hours = defaultdict(float)
 
     if data.get("features"):
         for feat in data["features"]:
@@ -127,6 +174,10 @@ def generate_report(river_name, river_label, rivers_to_query, ref_lat, ref_lon, 
             if start and end and lat is not None and lon is not None and upstream_func(lat, lon):
                 duration_seconds = (end - start) / 1000
                 dist = haversine(ref_lat, ref_lon, lat, lon)
+                # Attribute the full event duration to its start day (all upstream
+                # events in the fetched window, not just the last two days).
+                event_day = datetime.utcfromtimestamp(start / 1000).date()
+                by_day_hours[event_day] += duration_seconds / 3600
                 # The distance-band table / risk use only the last two days.
                 if start >= two_days_ago_ms:
                     for i, edge in enumerate(band_edges):
@@ -166,6 +217,30 @@ def generate_report(river_name, river_label, rivers_to_query, ref_lat, ref_lon, 
             f"<div class='risk-note'>If there is no further rain, the risk will be low at {safe_time} UTC</div>"
         )
 
+    # Build the recent-history chart series (CSO same-day / trailing-2d /
+    # trailing-7d spill hours, daily rainfall and mean temperature) in the style
+    # of the 2025 review page. One row per calendar day over the last CHART_DAYS.
+    weather = get_daily_weather(ref_lat, ref_lon, CHART_DAYS)
+
+    def trailing(day, n):
+        return round(sum(by_day_hours.get(day - timedelta(days=k), 0.0) for k in range(n)), 2)
+
+    chart_rows = []
+    day = (now - timedelta(days=CHART_DAYS)).date()
+    today = now.date()
+    while day <= today:
+        rain, temp = weather.get(day.isoformat(), (None, None))
+        chart_rows.append({
+            "d": day.isoformat(),
+            "cs": round(by_day_hours.get(day, 0.0), 2),
+            "c2": trailing(day, 2),
+            "c": trailing(day, 7),
+            "r": round(rain, 1) if rain is not None else None,
+            "t": round(temp, 1) if temp is not None else None,
+        })
+        day += timedelta(days=1)
+    chart_data = json.dumps(chart_rows)
+
     template_path = os.path.join("templates", "report_template.html")
     with open(template_path, "r", encoding="utf-8") as tpl_file:
         tpl = Template(tpl_file.read())
@@ -179,6 +254,7 @@ def generate_report(river_name, river_label, rivers_to_query, ref_lat, ref_lon, 
         table_rows=table_rows,
         weather_message=weather_message,
         risk_note_block=risk_note_block,
+        chart_data=chart_data,
     )
 
     os.makedirs("docs", exist_ok=True)

--- a/templates/report_template.html
+++ b/templates/report_template.html
@@ -28,6 +28,119 @@ $risk_note_block
     $table_rows
 </table>
 <div class="rain-warning">$weather_message</div>
+
+<style>
+/* Palette matches the always-light "theme-ocean" report page (the report pages
+   have no dark mode of their own, so the chart stays light too). */
+#chart-wrap{--surface:#f0fbff;--ink:#023859;--ink2:#02556e;--grid:#bfe0f2;--cso:#4a3aa7;--rain:#025e8f;--temp:#eb6834;max-width:960px;margin:2em auto 0;font-family:Arial,sans-serif;color:var(--ink);text-align:left}
+#chart-wrap h2{font-size:1.2em;text-align:center;margin:0 0 .2em;color:var(--ink)}
+#chart-wrap .csub{color:var(--ink2);font-size:.85em;text-align:center;margin:.2em auto 1.2em;line-height:1.45;max-width:820px}
+#chart-wrap .csub a{color:var(--rain)}
+#chart-wrap svg{display:block;width:100%;overflow:visible}
+#chart-wrap .cpanel{position:relative;margin-bottom:2px}
+.cgrid{stroke:var(--grid);stroke-width:1}
+.ctick{fill:var(--ink2);font-size:.62rem}
+.cplabel{font-size:.75rem;font-weight:600;fill:var(--ink)}
+.cpunit{font-size:.68rem;fill:var(--ink2)}
+.ccross{stroke:var(--ink2);stroke-width:1;stroke-dasharray:3 3;opacity:.6}
+#ctip{position:fixed;pointer-events:none;background:var(--surface);border:1px solid var(--grid);border-radius:8px;padding:.5em .6em;font-size:.75rem;box-shadow:0 4px 14px rgba(0,0,0,.18);z-index:9;min-width:150px;color:var(--ink)}
+#ctip b{display:block;margin-bottom:.3em}
+#ctip .crow{display:flex;justify-content:space-between;gap:1em}
+#ctip .csw{display:inline-block;width:9px;height:9px;border-radius:2px;margin-right:5px;vertical-align:middle}
+</style>
+<div id="chart-wrap">
+  <h2>Recent CSO spilling, rainfall &amp; temperature</h2>
+  <div class="csub">Upstream storm-overflow spill hours &mdash; same day, and trailing 2- and 7-day cumulative sums (the three CSO panels share one y-axis) &mdash; with daily rainfall and mean temperature over the last 45 days, in the style of the <a href="2025.html">2025 review</a>. Hover for values.</div>
+  <div id="chart-panels"></div>
+</div>
+<div id="ctip" hidden></div>
+<script>
+(function(){
+var DATA=$chart_data;
+if(!DATA||!DATA.length)return;
+var wrap=document.getElementById('chart-wrap');
+function cssv(n){return getComputedStyle(wrap).getPropertyValue(n).trim();}
+var days=DATA.map(function(d){return d.d;});
+var t0=Date.parse(days[0]),t1=Date.parse(days[days.length-1]);
+if(t1===t0){t1=t0+86400000;}
+var M={l:46,r:12,t:16,b:16};
+var W=880,H=92;
+var MON=['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+function xOf(ds){return M.l+(Date.parse(ds)-t0)/(t1-t0)*(W-M.l-M.r);}
+function niceMax(v){if(!(v>0)){return 1;}var p=Math.pow(10,Math.floor(Math.log10(v)));var n=v/p;var m=n<=1?1:n<=2?2:n<=5?5:10;return m*p;}
+function fmtDate(ds){var d=new Date(ds);return d.getUTCDate()+' '+MON[d.getUTCMonth()];}
+var csoMax=niceMax(Math.max.apply(null,DATA.map(function(d){return Math.max(d.cs||0,d.c2||0,d.c||0);})));
+var rainMax=niceMax(Math.max.apply(null,DATA.map(function(d){return d.r||0;})));
+var temps=DATA.map(function(d){return d.t;}).filter(function(v){return v!=null;});
+var tMax=niceMax(temps.length?Math.max.apply(null,temps):20);
+var panels=[
+ {key:'cs',label:'CSO spilling',unit:'hours, same day',color:'--cso',kind:'bar',max:csoMax,min:0},
+ {key:'c2',label:'CSO spilling',unit:'hours, trailing 2 days (cumulative)',color:'--cso',kind:'bar',max:csoMax,min:0},
+ {key:'c',label:'CSO spilling',unit:'hours, trailing 7 days (cumulative)',color:'--cso',kind:'bar',max:csoMax,min:0},
+ {key:'r',label:'Rainfall',unit:'mm/day',color:'--rain',kind:'bar',max:rainMax,min:0},
+ {key:'t',label:'Temperature',unit:'°C daily mean',color:'--temp',kind:'line',max:tMax,min:0}
+];
+function el(t,a){var e=document.createElementNS('http://www.w3.org/2000/svg',t);for(var k in a){e.setAttribute(k,a[k]);}return e;}
+function txt(x,y,s,a){var e=el('text',Object.assign({x:x,y:y},a));e.textContent=s;return e;}
+function fmtTick(v){return (v%1)?v.toFixed(1):String(v);}
+function render(){
+  var cont=document.getElementById('chart-panels');cont.innerHTML='';
+  W=cont.clientWidth||880;
+  var weeks=[];var wk=new Date(t0);var add=(1-wk.getUTCDay()+7)%7;wk.setUTCDate(wk.getUTCDate()+add);
+  while(wk.getTime()<=t1){weeks.push(new Date(wk));wk.setUTCDate(wk.getUTCDate()+7);}
+  var dayW=(W-M.l-M.r)/Math.max(days.length-1,1);
+  var barW=Math.max(2,Math.min(dayW*0.7,9));
+  panels.forEach(function(p,pi){
+    var mn=p.min||0,mx=p.max,yA=(H-M.t-M.b),yBase=H-M.b;
+    function yScale(v){return M.t+(1-(v-mn)/(mx-mn))*yA;}
+    var svg=el('svg',{viewBox:'0 0 '+W+' '+H,role:'img','aria-label':p.label});
+    [mn,(mn+mx)/2,mx].forEach(function(tk){var y=yScale(tk);
+      svg.appendChild(el('line',{'class':'cgrid',x1:M.l,y1:y,x2:W-M.r,y2:y}));
+      svg.appendChild(txt(M.l-5,y+3,fmtTick(tk),{'class':'ctick','text-anchor':'end'}));});
+    weeks.forEach(function(w){var x=xOf(w.toISOString().slice(0,10));
+      svg.appendChild(el('line',{'class':'cgrid',x1:x,y1:M.t,x2:x,y2:yBase,opacity:0.45}));
+      if(pi===panels.length-1){svg.appendChild(txt(x,H-2,fmtDate(w.toISOString().slice(0,10)),{'class':'ctick','text-anchor':'middle'}));}});
+    svg.appendChild(txt(M.l,11,p.label,{'class':'cplabel'}));
+    svg.appendChild(txt(M.l+p.label.length*6.4+8,11,p.unit,{'class':'cpunit'}));
+    var col=cssv(p.color);
+    if(p.kind==='bar'){
+      DATA.forEach(function(d){var v=d[p.key];if(v==null||v<=0){return;}var x=xOf(d.d),y=yScale(Math.min(v,mx));
+        svg.appendChild(el('rect',{x:x-barW/2,y:y,width:barW,height:yBase-y,fill:col,rx:1}));});
+    }else{
+      var pts=DATA.filter(function(d){return d[p.key]!=null;}).map(function(d){return xOf(d.d)+','+yScale(Math.min(d[p.key],mx));}).join(' ');
+      svg.appendChild(el('polyline',{points:pts,fill:'none',stroke:col,'stroke-width':2,'stroke-linejoin':'round'}));
+    }
+    svg.appendChild(el('line',{'class':'ccross',x1:0,y1:M.t,x2:0,y2:yBase,visibility:'hidden'}));
+    var div=document.createElement('div');div.className='cpanel';div.appendChild(svg);cont.appendChild(div);
+  });
+  attachHover(cont);
+}
+function attachHover(cont){
+  var tip=document.getElementById('ctip');
+  cont.addEventListener('pointermove',function(e){
+    var rect=cont.getBoundingClientRect();var px=e.clientX-rect.left;
+    var frac=(px-M.l)/(W-M.l-M.r);var tt=t0+frac*(t1-t0);
+    var best=null,bd=1e18;DATA.forEach(function(d){var dt=Math.abs(Date.parse(d.d)-tt);if(dt<bd){bd=dt;best=d;}});
+    var chs=cont.querySelectorAll('.ccross');
+    if(!best||frac<-0.02||frac>1.02){tip.hidden=true;chs.forEach(function(c){c.setAttribute('visibility','hidden');});return;}
+    var x=xOf(best.d);chs.forEach(function(c){c.setAttribute('x1',x);c.setAttribute('x2',x);c.setAttribute('visibility','visible');});
+    var rows=[
+      ['--cso','CSO same day',(best.cs==null?0:best.cs).toFixed(1)+' h'],
+      ['--cso','CSO trailing 2d',(best.c2==null?0:best.c2).toFixed(1)+' h'],
+      ['--cso','CSO trailing 7d',(best.c==null?0:best.c).toFixed(1)+' h'],
+      ['--rain','Rain',(best.r==null?0:best.r).toFixed(1)+' mm']
+    ];
+    if(best.t!=null){rows.push(['--temp','Temp',best.t.toFixed(1)+' °C']);}
+    tip.innerHTML='<b>'+fmtDate(best.d)+'</b>'+rows.map(function(r){return '<div class="crow"><span><span class="csw" style="background:'+cssv(r[0])+'"></span>'+r[1]+'</span><span>'+r[2]+'</span></div>';}).join('');
+    tip.hidden=false;var tx=e.clientX+14;if(tx+170>window.innerWidth){tx=e.clientX-180;}
+    tip.style.left=tx+'px';tip.style.top=(e.clientY+12)+'px';
+  });
+  cont.addEventListener('pointerleave',function(){tip.hidden=true;cont.querySelectorAll('.ccross').forEach(function(c){c.setAttribute('visibility','hidden');});});
+}
+render();window.addEventListener('resize',render);
+})();
+</script>
+
 <div class="disclaimer">
     This tool uses a simplified "upstream" test based on longitude and/or latitude. For Conham, CSOs east of the site are counted as upstream. This may include or miss some actual upstream sources, especially in complex river sections.
     <br>Distances are as the crow flies (not measured along the river or watercourse).


### PR DESCRIPTION
Each per-site report page now renders a multi-panel history chart in the
style of the 2025 review page: upstream CSO spill hours (same day, and
trailing 2- and 7-day cumulative sums, sharing one y-axis), daily rainfall
and daily mean temperature over the last 45 days.

poo.py:
- Widen the storm-overflow feed query to a 45-day (+7-day pre-roll) window
  so the trailing CSO sums are complete from the first plotted day; risk and
  the distance-band table are unchanged (still last-2-days only).
- Aggregate upstream spill hours per calendar day (by event start day) into
  same-day / trailing-2d / trailing-7d series.
- Fetch daily rainfall and mean temperature from open-meteo (past_days) and
  emit the combined series as JSON into the report template.

report_template.html:
- Add a self-contained SVG chart (dynamic axes, weekly gridlines, hover
  tooltip) with light palette matching the report page.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TmwPzV9DUSCtAXrWRBm92V